### PR TITLE
Improve daemon wake flow and support runtime-specific agent IDs

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -404,22 +404,21 @@ pub fn search(
 /// Start a background daemon that watches the room via SSE.
 /// Writes a JSON flag file on new messages for hook consumption.
 /// Returns the child PID.
-pub fn daemon(room_label: Option<&str>, flag_path: &str, pid_path: &str) -> Result<u32, String> {
+pub fn daemon(room_label: Option<&str>) -> Result<u32, String> {
     let room = resolve_room(room_label)?;
+    let pid_path = store::daemon_pid_path(&room.room_id);
 
     // Kill existing daemon if running
-    if let Ok(pid_str) = std::fs::read_to_string(pid_path) {
+    if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
             unsafe { libc::kill(pid, libc::SIGTERM); }
         }
-        let _ = std::fs::remove_file(pid_path);
+        let _ = std::fs::remove_file(&pid_path);
     }
 
     let room_id = room.room_id.clone();
     let secret = room.secret.clone();
-    let label = room.label.clone();
-    let flag = flag_path.to_string();
-    let pidfile = pid_path.to_string();
+    let pidfile = pid_path;
 
     // Fork
     let pid = unsafe { libc::fork() };
@@ -438,21 +437,16 @@ pub fn daemon(room_label: Option<&str>, flag_path: &str, pid_path: &str) -> Resu
     let room_key = crypto::derive_room_key(&secret, &room_id);
     let me = store::get_agent_id();
 
-    transport::stream(&room_id, |ts, payload| {
+    transport::stream(&room_id, |_ts, payload| {
         if let Some(env) = decrypt_payload(payload, &room_key, &room_id) {
+            track_presence(&room_id, &env);
             let from = env["from"].as_str().unwrap_or("");
             // Skip own messages and heartbeats
             if from == me || is_heartbeat(&env) {
                 return;
             }
-            let text = env["text"].as_str().unwrap_or("").to_string();
-            let flag_data = serde_json::json!({
-                "room": label,
-                "from": from,
-                "text": if text.len() > 200 { &text[..200] } else { &text },
-                "time": ts,
-            });
-            let _ = std::fs::write(&flag, serde_json::to_string(&flag_data).unwrap());
+            store::save_message(&room_id, &env);
+            store::set_notify_flag(&room_id, &env);
         }
     });
 
@@ -460,30 +454,35 @@ pub fn daemon(room_label: Option<&str>, flag_path: &str, pid_path: &str) -> Resu
 }
 
 /// Check the flag file for new messages (for hooks). Clears the flag.
-/// Returns the notification text, or empty if no new messages.
-pub fn notify(flag_path: &str) -> String {
-    let path = std::path::Path::new(flag_path);
-    if !path.exists() {
-        return String::new();
+/// Returns cached unseen messages, or empty if no new messages.
+pub fn notify(since: &str, room_label: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+    let room = resolve_room(room_label)?;
+    if !store::take_notify_flag(&room.room_id) {
+        return Ok(vec![]);
     }
-    let data = match std::fs::read_to_string(path) {
-        Ok(d) => d,
-        Err(_) => return String::new(),
-    };
-    let _ = std::fs::remove_file(path);
-    if let Ok(flag) = serde_json::from_str::<serde_json::Value>(&data) {
-        let room = flag["room"].as_str().unwrap_or("?");
-        let from = flag["from"].as_str().unwrap_or("?");
-        let text = flag["text"].as_str().unwrap_or("");
-        format!("[{room}] {from}: {text}")
-    } else {
-        String::new()
+
+    let me = store::get_agent_id();
+    let seen = store::load_seen(&room.room_id);
+    let since_secs = parse_since(since);
+    let mut new_msgs = Vec::new();
+
+    for env in store::load_messages(&room.room_id, since_secs) {
+        let mid = env["id"].as_str().unwrap_or("?").to_string();
+        let from = env["from"].as_str().unwrap_or("");
+        if from == me || seen.contains(&mid) || is_heartbeat(&env) {
+            continue;
+        }
+        store::mark_seen(&room.room_id, &mid);
+        new_msgs.push(env);
     }
+    Ok(new_msgs)
 }
 
 /// Stop the daemon process.
-pub fn stop_daemon(pid_path: &str) -> Result<(), String> {
-    if let Ok(pid_str) = std::fs::read_to_string(pid_path) {
+pub fn stop_daemon(room_label: Option<&str>) -> Result<(), String> {
+    let room = resolve_room(room_label)?;
+    let pid_path = store::daemon_pid_path(&room.room_id);
+    if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
             unsafe { libc::kill(pid, libc::SIGTERM); }
             let _ = std::fs::remove_file(pid_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -452,8 +452,18 @@ fn main() {
         }
 
         Commands::Daemon => {
-            match chat::daemon(None, "/tmp/.agora_notify", "/tmp/.agora_daemon.pid") {
-                Ok(pid) => println!("  Daemon started (PID {pid}). Watching for messages.\n  Hook: agora notify --wake"),
+            match chat::daemon(None) {
+                Ok(pid) => {
+                    if let Some(room) = store::get_active_room() {
+                        println!(
+                            "  Daemon started (PID {pid}) for '{}'.\n  Notify flag: {}\n  Hook: agora notify --wake",
+                            room.label,
+                            store::notify_flag_path(&room.room_id).display()
+                        );
+                    } else {
+                        println!("  Daemon started (PID {pid}).\n  Hook: agora notify --wake");
+                    }
+                }
                 Err(e) => {
                     eprintln!("  Error: {e}");
                     process::exit(1);
@@ -462,17 +472,26 @@ fn main() {
         }
 
         Commands::Notify { wake } => {
-            let msg = chat::notify("/tmp/.agora_notify");
-            if !msg.is_empty() {
-                println!("  {msg}");
-                if wake {
-                    process::exit(2);
+            match chat::notify("24h", None) {
+                Ok(msgs) => {
+                    if !msgs.is_empty() {
+                        for m in &msgs {
+                            print_msg(m);
+                        }
+                        if wake {
+                            process::exit(2);
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
                 }
             }
         }
 
         Commands::Stop => {
-            match chat::stop_daemon("/tmp/.agora_daemon.pid") {
+            match chat::stop_daemon(None) {
                 Ok(()) => println!("  Daemon stopped."),
                 Err(e) => eprintln!("  {e}"),
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -266,6 +266,35 @@ pub fn load_messages(room_id: &str, since_secs: u64) -> Vec<serde_json::Value> {
     msgs
 }
 
+pub fn notify_flag_path(room_id: &str) -> PathBuf {
+    let dir = agora_dir().join("rooms").join(room_id);
+    ensure_dir(&dir);
+    dir.join("notify.flag")
+}
+
+pub fn daemon_pid_path(room_id: &str) -> PathBuf {
+    let dir = agora_dir().join("rooms").join(room_id);
+    ensure_dir(&dir);
+    dir.join("daemon.pid")
+}
+
+pub fn set_notify_flag(room_id: &str, envelope: &serde_json::Value) {
+    let path = notify_flag_path(room_id);
+    let mid = envelope["id"].as_str().unwrap_or("?");
+    let ts = envelope["ts"].as_u64().unwrap_or_else(now);
+    let payload = format!("{ts}\t{mid}\n");
+    let _ = fs::write(path, payload);
+}
+
+pub fn take_notify_flag(room_id: &str) -> bool {
+    let path = notify_flag_path(room_id);
+    let exists = path.exists();
+    if exists {
+        let _ = fs::remove_file(path);
+    }
+    exists
+}
+
 // ── Seen Tracking ───────────────────────────────────────────────
 
 pub fn load_seen(room_id: &str) -> HashSet<String> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -32,6 +32,13 @@ fn now() -> u64 {
 // ── Identity ────────────────────────────────────────────────────
 
 pub fn get_agent_id() -> String {
+    // Env override — lets multiple runtimes on the same machine have distinct IDs.
+    if let Ok(id) = std::env::var("AGORA_AGENT_ID") {
+        if !id.is_empty() {
+            return id;
+        }
+    }
+
     let id_file = agora_dir().join("identity.json");
     if let Ok(data) = fs::read_to_string(&id_file) {
         if let Ok(v) = serde_json::from_str::<serde_json::Value>(&data) {


### PR DESCRIPTION
## Summary
- make daemon state room-scoped by storing PID and notify files under `~/.agora/rooms/<room_id>/`
- have the daemon cache full decrypted messages locally and make `agora notify --wake` surface unseen cached messages instead of a single overwritten summary
- allow `AGORA_AGENT_ID` to override the shared local identity so Claude Code and Codex can coexist on the same machine without colliding

## Validation
- `cargo build --release`
- `AGORA_AGENT_ID=9d107f-cx ./target/release/agora id`
- fixture run with cached unseen messages: first `notify --wake` exits `2`, second exits `0` after clearing the room flag

## Notes
- kept this PR code-only to avoid overlapping with the README work another agent already claimed
- this bundles the local Claude's identity override with the daemon follow-up so the local runtime coordination issue is addressed in one review
