### PR TITLE
Add room leave command

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -158,6 +158,31 @@ pub fn join(room_id: &str, secret: &str, label: &str) -> Result<store::RoomEntry
     Ok(entry)
 }
 
+pub fn leave(room_label: Option<&str>) -> Result<serde_json::Value, String> {
+    let room = resolve_room(room_label)?;
+    let pid_path = store::daemon_pid_path(&room.room_id);
+    let mut daemon_stopped = false;
+
+    if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
+        if let Ok(pid) = pid_str.trim().parse::<i32>() {
+            unsafe { libc::kill(pid, libc::SIGTERM); }
+            daemon_stopped = true;
+        }
+        let _ = std::fs::remove_file(&pid_path);
+    }
+
+    let removed = store::remove_room(&room.room_id)
+        .ok_or_else(|| format!("Room '{}' not found.", room.label))?;
+    let active_room = store::get_active_room().map(|r| r.label);
+
+    Ok(json!({
+        "label": removed.label,
+        "room_id": removed.room_id,
+        "daemon_stopped": daemon_stopped,
+        "active_room": active_room,
+    }))
+}
+
 pub fn heartbeat(room_label: Option<&str>) -> Result<(), String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,9 @@ enum Commands {
         label: String,
     },
 
+    /// Leave a room and remove its local state
+    Leave,
+
     /// Show room info + key fingerprint
     Info,
 
@@ -317,6 +320,26 @@ fn main() {
                 }
                 None => {
                     eprintln!("  Room '{label}' not found. Run: agora rooms");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Leave => {
+            match chat::leave(room) {
+                Ok(info) => {
+                    println!("  Left room '{}'.", info["label"].as_str().unwrap_or("?"));
+                    if info["daemon_stopped"].as_bool().unwrap_or(false) {
+                        println!("  Daemon stopped.");
+                    }
+                    if let Some(active_room) = info["active_room"].as_str() {
+                        println!("  Active room: {active_room}");
+                    } else {
+                        println!("  No rooms left.");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
                     process::exit(1);
                 }
             }

--- a/src/store.rs
+++ b/src/store.rs
@@ -232,6 +232,34 @@ pub fn set_active_room(label: &str) {
     let _ = fs::write(dir.join("active_room"), label);
 }
 
+pub fn remove_room(label_or_id: &str) -> Option<RoomEntry> {
+    let mut rooms = load_registry();
+    let idx = rooms
+        .iter()
+        .position(|r| r.label == label_or_id || r.room_id == label_or_id)?;
+    let removed = rooms.remove(idx);
+    save_registry(&rooms);
+
+    let room_dir = agora_dir().join("rooms").join(&removed.room_id);
+    if room_dir.exists() {
+        let _ = fs::remove_dir_all(&room_dir);
+    }
+
+    let active_file = agora_dir().join("active_room");
+    if let Ok(active) = fs::read_to_string(&active_file) {
+        let active = active.trim();
+        if active == removed.label || active == removed.room_id {
+            if let Some(next) = rooms.first() {
+                let _ = fs::write(&active_file, &next.label);
+            } else {
+                let _ = fs::remove_file(&active_file);
+            }
+        }
+    }
+
+    Some(removed)
+}
+
 // ── Message Persistence ─────────────────────────────────────────
 
 pub fn save_message(room_id: &str, envelope: &serde_json::Value) {


### PR DESCRIPTION
## Summary
- add `agora leave` to remove a joined room from the local registry and local room cache
- stop any room-scoped daemon before removing the room state
- repair `active_room` by falling back to the next joined room or removing it when no rooms remain

## Behavior
- `agora leave` leaves the active room
- `agora --room <label> leave` leaves that room without changing the active room unless it was the active one
- local-only semantics: this removes local access and cache for the room rather than attempting remote membership revocation

## Validation
- `cargo build --release`
- disposable HOME fixture with two rooms
- verified leaving a non-active room stops its daemon pid, removes its room directory/registry entry, and keeps the active room unchanged
- verified leaving the final active room removes `active_room` and leaves no rooms in the registry
