### PR TITLE
Add local per-room message pinning

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -459,6 +459,27 @@ fn resolve_message_id(msgs: &[serde_json::Value], needle: &str) -> Result<String
     }
 }
 
+fn resolve_saved_id(ids: &[String], needle: &str) -> Result<String, String> {
+    if ids.iter().any(|id| id == needle) {
+        return Ok(needle.to_string());
+    }
+
+    let matches: Vec<String> = ids
+        .iter()
+        .filter(|id| id.starts_with(needle))
+        .cloned()
+        .collect();
+
+    match matches.len() {
+        0 => Err(format!("Message '{needle}' is not pinned.")),
+        1 => Ok(matches[0].clone()),
+        _ => Err(format!(
+            "Message ID '{needle}' is ambiguous: {}",
+            matches.into_iter().take(5).collect::<Vec<_>>().join(", ")
+        )),
+    }
+}
+
 fn walk_thread(
     env: &serde_json::Value,
     depth: usize,
@@ -520,6 +541,55 @@ pub fn thread(message_id: &str, room_label: Option<&str>) -> Result<Vec<ThreadIt
     let root = root.ok_or_else(|| format!("Message '{message_id}' not found in local cache."))?;
     let mut out = Vec::new();
     walk_thread(&root, 0, &children, &mut out);
+    Ok(out)
+}
+
+pub fn pin(message_id: &str, room_label: Option<&str>) -> Result<(String, bool), String> {
+    let room = resolve_room(room_label)?;
+    let msgs = store::load_messages(&room.room_id, u64::MAX);
+    if msgs.is_empty() {
+        return Err("No cached messages for the active room.".to_string());
+    }
+
+    let resolved_id = resolve_message_id(&msgs, message_id)?;
+    let added = store::add_pin(&room.room_id, &resolved_id);
+    Ok((resolved_id, added))
+}
+
+pub fn unpin(message_id: &str, room_label: Option<&str>) -> Result<(String, bool), String> {
+    let room = resolve_room(room_label)?;
+    let pins = store::load_pins(&room.room_id);
+    if pins.is_empty() {
+        return Err("No pinned messages for the active room.".to_string());
+    }
+
+    let resolved_id = resolve_saved_id(&pins, message_id)?;
+    let removed = store::remove_pin(&room.room_id, &resolved_id);
+    Ok((resolved_id, removed))
+}
+
+pub fn pins(room_label: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+    let room = resolve_room(room_label)?;
+    let pinned_ids = store::load_pins(&room.room_id);
+    if pinned_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let msgs = store::load_messages(&room.room_id, u64::MAX);
+    let by_id: HashMap<String, serde_json::Value> = msgs
+        .into_iter()
+        .filter_map(|msg| {
+            let id = msg["id"].as_str()?.to_string();
+            Some((id, msg))
+        })
+        .collect();
+
+    let mut out = Vec::new();
+    for id in pinned_ids {
+        if let Some(msg) = by_id.get(&id) {
+            out.push(msg.clone());
+        }
+    }
     Ok(out)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,21 @@ enum Commands {
         from: Option<String>,
     },
 
+    /// Pin a cached message locally in this room
+    Pin {
+        /// Message ID or unique prefix
+        message_id: String,
+    },
+
+    /// Remove a local pin from this room
+    Unpin {
+        /// Message ID or unique prefix
+        message_id: String,
+    },
+
+    /// List pinned messages for this room
+    Pins,
+
     /// Show a message thread from the local cache
     Thread {
         /// Message ID or unique prefix
@@ -262,6 +277,15 @@ fn main() {
                     };
                     if let Some(header_room) = header_room {
                         println!("  --- {} ({} messages, AES-256-GCM) ---\n", header_room.label, msgs.len());
+                    }
+                    if let Ok(pinned) = chat::pins(room) {
+                        if !pinned.is_empty() {
+                            println!("  --- pinned ({}) ---\n", pinned.len());
+                            for p in &pinned {
+                                print_msg(p);
+                            }
+                            println!();
+                        }
                     }
                     for m in msgs {
                         print_msg(m);
@@ -493,6 +517,59 @@ fn main() {
                     println!("  {} match(es) for '{q}':\n", msgs.len());
                     for m in &msgs {
                         print_msg(m);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Pin { message_id } => {
+            match chat::pin(&message_id, room) {
+                Ok((resolved_id, added)) => {
+                    let short = &resolved_id[..6.min(resolved_id.len())];
+                    if added {
+                        println!("  Pinned [{short}].");
+                    } else {
+                        println!("  Already pinned [{short}].");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Unpin { message_id } => {
+            match chat::unpin(&message_id, room) {
+                Ok((resolved_id, removed)) => {
+                    let short = &resolved_id[..6.min(resolved_id.len())];
+                    if removed {
+                        println!("  Unpinned [{short}].");
+                    } else {
+                        println!("  [{short}] was not pinned.");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Pins => {
+            match chat::pins(room) {
+                Ok(pinned) => {
+                    if pinned.is_empty() {
+                        println!("  (no pinned messages)");
+                        return;
+                    }
+                    println!("  {} pinned message(s):\n", pinned.len());
+                    for p in &pinned {
+                        print_msg(p);
                     }
                 }
                 Err(e) => {

--- a/src/store.rs
+++ b/src/store.rs
@@ -307,6 +307,47 @@ pub fn notify_flag_path(room_id: &str) -> PathBuf {
     dir.join("notify.flag")
 }
 
+pub fn pins_path(room_id: &str) -> PathBuf {
+    let dir = agora_dir().join("rooms").join(room_id);
+    ensure_dir(&dir);
+    dir.join("pins.json")
+}
+
+pub fn load_pins(room_id: &str) -> Vec<String> {
+    let path = pins_path(room_id);
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+pub fn save_pins(room_id: &str, pins: &[String]) {
+    let path = pins_path(room_id);
+    let _ = fs::write(path, serde_json::to_string_pretty(pins).unwrap());
+}
+
+pub fn add_pin(room_id: &str, message_id: &str) -> bool {
+    let mut pins = load_pins(room_id);
+    if pins.iter().any(|id| id == message_id) {
+        return false;
+    }
+    pins.push(message_id.to_string());
+    save_pins(room_id, &pins);
+    true
+}
+
+pub fn remove_pin(room_id: &str, message_id: &str) -> bool {
+    let mut pins = load_pins(room_id);
+    let before = pins.len();
+    pins.retain(|id| id != message_id);
+    if pins.len() == before {
+        return false;
+    }
+    save_pins(room_id, &pins);
+    true
+}
+
 pub fn daemon_pid_path(room_id: &str) -> PathBuf {
     let dir = agora_dir().join("rooms").join(room_id);
     ensure_dir(&dir);


### PR DESCRIPTION
## Summary
- add local per-room message pinning with `agora pin <id>`, `agora unpin <id>`, and `agora pins`
- store pinned message IDs under each room's local state so pins survive restarts
- show a small pinned section at the top of `agora read`

## Scope
This is intentionally a local-only first cut:
- pins are stored in local room state under `~/.agora/rooms/<room_id>/`
- pinning does not publish a room event or try to synchronize across clients
- the goal is quick utility and a discussion artifact for whether shared/synced pins are worth adding later

## Validation
- `cargo build --release`
- disposable HOME fixture covering `pin`, `pins`, `read`, and `unpin`
- verified prefix pinning works, pinned messages show up in `read`, and unpin removes them again
