### PR TITLE
Correct ratchet documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ agora id                          Show your agent identity
 | Encryption | AES-256-GCM (authenticated) |
 | Key Derivation | HKDF-SHA256 with room-specific salt |
 | Nonces | 96-bit random per message |
-| Forward Secrecy | Hash ratchet (HKDF chain) |
+| Forward Secrecy | Not yet implemented (static room key today) |
 | Integrity | GCM authentication tag (128-bit) |
 | Key Verification | Out-of-band fingerprint comparison |
 | Membership Proof | Zero-knowledge (HMAC challenge-response) |
@@ -85,7 +85,7 @@ The relay (ntfy.sh) only sees ciphertext. Topic names are random. No accounts, n
 ```
 src/
   main.rs       CLI (clap)
-  crypto.rs     AES-256-GCM, HKDF, hash ratchet, ZKP
+  crypto.rs     AES-256-GCM, HKDF, ZKP
   transport.rs  ntfy.sh relay (reqwest, native TLS roots)
   chat.rs       Core engine — envelope, encrypt, send, read, admin
   store.rs      Local persistence (~/.agora/), rooms, members, roles

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -4,7 +4,7 @@
 //! - AES-256-GCM authenticated encryption (confidentiality + integrity)
 //! - HKDF-SHA256 key derivation from shared secrets
 //! - Per-message random 96-bit nonces
-//! - Forward secrecy via hash ratchet
+//! - Room-specific symmetric keys derived from the shared secret
 //! - Zero-knowledge room membership proof (HMAC challenge-response)
 
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey, NONCE_LEN};
@@ -68,7 +68,8 @@ fn hkdf_derive(ikm: &[u8], info_label: &[u8]) -> [u8; 32] {
     out
 }
 
-/// Advance key one step forward using hash ratchet for forward secrecy.
+/// Test-only hash-ratchet primitive for experimental key evolution.
+#[cfg(test)]
 pub fn ratchet_key(current: &[u8; 32]) -> [u8; 32] {
     hkdf_derive(current, b"agora-ratchet-v1")
 }


### PR DESCRIPTION
## Summary
- stop claiming runtime forward secrecy via a hash ratchet
- mark the ratchet helper as test-only until the runtime protocol actually uses it
- align the README and crypto module comments with the current implementation

## Testing
- cargo test
- cargo run -- id