### PR TITLE
crypto: per-sender ratchet primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ agora id                          Show your agent identity
 | Encryption | AES-256-GCM (authenticated) |
 | Key Derivation | HKDF-SHA256 with room-specific salt |
 | Nonces | 96-bit random per message |
-| Forward Secrecy | Hash ratchet (HKDF chain) |
+| Forward Secrecy | Not yet implemented (static room key today) |
 | Integrity | GCM authentication tag (128-bit) |
 | Key Verification | Out-of-band fingerprint comparison |
 | Membership Proof | Zero-knowledge (HMAC challenge-response) |
@@ -85,7 +85,7 @@ The relay (ntfy.sh) only sees ciphertext. Topic names are random. No accounts, n
 ```
 src/
   main.rs       CLI (clap)
-  crypto.rs     AES-256-GCM, HKDF, hash ratchet, ZKP
+  crypto.rs     AES-256-GCM, HKDF, ZKP
   transport.rs  ntfy.sh relay (reqwest, native TLS roots)
   chat.rs       Core engine — envelope, encrypt, send, read, admin
   store.rs      Local persistence (~/.agora/), rooms, members, roles

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -126,7 +126,13 @@ fn resolve_room(label: Option<&str>) -> Result<store::RoomEntry, String> {
     } else {
         store::get_active_room()
     };
-    room.ok_or_else(|| "No active room. Use 'agora create' or 'agora join' first.".to_string())
+    room.ok_or_else(|| {
+        if let Some(label) = label {
+            format!("Room '{label}' not found. Run: agora rooms")
+        } else {
+            "No active room. Use 'agora create' or 'agora join' first.".to_string()
+        }
+    })
 }
 
 pub fn create(label: &str) -> Result<(String, String), String> {
@@ -408,7 +414,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::send_watch_heartbeat;
+    use super::{resolve_room, send_watch_heartbeat};
     use crate::store::{self, Role};
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -429,6 +435,19 @@ mod tests {
             .find(|m| m.agent_id == me)
             .map(|m| m.last_seen)
             .unwrap_or(0)
+    }
+
+    #[test]
+    fn resolve_room_reports_missing_explicit_target() {
+        let home = temp_home();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "watch-test");
+        }
+
+        let err = resolve_room(Some("missing-room")).unwrap_err();
+        assert_eq!(err, "Room 'missing-room' not found. Run: agora rooms");
     }
 
     #[test]

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,13 +1,17 @@
 //! Agora chat engine.
 //!
-//! Wire format: base64(nonce || AES-256-GCM(envelope_json, aad=room_id))
+//! Wire format:
+//! - v3 legacy: base64(nonce || AES-256-GCM(envelope_json, aad=room_id))
+//! - v4 ratchet: json({v, from, ratchet_n, ct}) where `ct` is
+//!   base64(nonce || AES-256-GCM(envelope_json, aad=room_id:from:ratchet_n))
 //!
 //! Envelope (plaintext JSON):
 //! ```json
 //! {
-//!     "v": "3.0",
+//!     "v": "4.0",
 //!     "id": "<8-hex message ID>",
 //!     "from": "<agent-id>",
+//!     "ratchet_n": <u64>,
 //!     "ts": <unix-timestamp>,
 //!     "text": "<message body>",
 //!     "reply_to": "<optional parent ID>"
@@ -24,7 +28,7 @@ use ring::rand::SecureRandom;
 
 use crate::{crypto, store, transport};
 
-const VERSION: &str = "3.0";
+const VERSION: &str = "4.0";
 const BASE64: base64::engine::general_purpose::GeneralPurpose =
     base64::engine::general_purpose::STANDARD;
 
@@ -145,9 +149,29 @@ fn parse_payload_frame(payload: &str) -> PayloadFrame {
     }
 }
 
+fn encode_chain_key(key: &[u8; 32]) -> String {
+    hex::encode(key)
+}
+
+fn decode_chain_key(encoded: Option<&str>) -> Option<[u8; 32]> {
+    let encoded = encoded?;
+    let bytes = hex::decode(encoded).ok()?;
+    if bytes.len() != 32 {
+        return None;
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&bytes);
+    Some(key)
+}
+
+fn ratchet_aad(room_id: &str, sender_id: &str, ratchet_n: u64) -> Vec<u8> {
+    format!("{room_id}:{sender_id}:{ratchet_n}").into_bytes()
+}
+
 // ── Encrypt / Decrypt ───────────────────────────────────────────
 
-fn encrypt_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str) -> String {
+#[cfg(test)]
+fn encrypt_legacy_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str) -> String {
     let (enc_key, _) = crypto::derive_message_keys(room_key);
     let plaintext = serde_json::to_string(env).unwrap();
     let aad = room_id.as_bytes();
@@ -155,14 +179,85 @@ fn encrypt_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str)
     BASE64.encode(&blob)
 }
 
-fn decrypt_payload(payload: &str, room_key: &[u8; 32], room_id: &str) -> Option<serde_json::Value> {
-    let frame = parse_payload_frame(payload);
+fn encrypt_envelope(env: &mut serde_json::Value, room_key: &[u8; 32], room_id: &str) -> String {
+    let sender_id = env["from"]
+        .as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(store::get_agent_id);
+    let mut state = store::load_ratchet_state(room_id);
+    let chain_key = decode_chain_key(state.send_chain_key.as_deref())
+        .unwrap_or_else(|| crypto::init_sender_chain(room_key, &sender_id));
+    let ratchet_n = state.send_next_n;
+    env["ratchet_n"] = json!(ratchet_n);
+
+    let msg_key = crypto::derive_msg_key(&chain_key);
+    let plaintext = serde_json::to_string(env).unwrap();
+    let aad = ratchet_aad(room_id, &sender_id, ratchet_n);
+    let blob = crypto::encrypt(plaintext.as_bytes(), &msg_key, &aad).expect("encrypt failed");
+
+    let next_chain = crypto::advance_chain(&chain_key);
+    state.send_chain_key = Some(encode_chain_key(&next_chain));
+    state.send_next_n = ratchet_n + 1;
+    store::save_ratchet_state(room_id, &state);
+
+    wrap_ratchet_payload(&sender_id, ratchet_n, &BASE64.encode(&blob))
+}
+
+fn decrypt_legacy_payload(payload: &str, room_key: &[u8; 32], room_id: &str) -> Option<serde_json::Value> {
     let (enc_key, _) = crypto::derive_message_keys(room_key);
-    let blob = BASE64.decode(frame.ciphertext).ok()?;
+    let blob = BASE64.decode(payload).ok()?;
     let aad = room_id.as_bytes();
     let plaintext = crypto::decrypt(&blob, &enc_key, aad).ok()?;
     let raw = String::from_utf8(plaintext).ok()?;
     parse_envelope(&raw)
+}
+
+fn decrypt_ratchet_payload(
+    frame: &PayloadFrame,
+    room_key: &[u8; 32],
+    room_id: &str,
+) -> Option<serde_json::Value> {
+    let sender_id = frame.from.as_deref()?;
+    let ratchet_n = frame.ratchet_n?;
+    let mut state = store::load_ratchet_state(room_id);
+    let peer = state.recv.entry(sender_id.to_string()).or_default();
+
+    let mut chain_key = decode_chain_key(peer.chain_key.as_deref())
+        .unwrap_or_else(|| crypto::init_sender_chain(room_key, sender_id));
+    let mut current_n = peer.next_n;
+    if current_n > ratchet_n {
+        return None;
+    }
+    while current_n < ratchet_n {
+        chain_key = crypto::advance_chain(&chain_key);
+        current_n += 1;
+    }
+
+    let msg_key = crypto::derive_msg_key(&chain_key);
+    let blob = BASE64.decode(&frame.ciphertext).ok()?;
+    let aad = ratchet_aad(room_id, sender_id, ratchet_n);
+    let plaintext = crypto::decrypt(&blob, &msg_key, &aad).ok()?;
+    let raw = String::from_utf8(plaintext).ok()?;
+    let mut env = parse_envelope(&raw)?;
+    if env["from"].as_str() != Some(sender_id) {
+        return None;
+    }
+    env["ratchet_n"] = json!(ratchet_n);
+
+    let next_chain = crypto::advance_chain(&chain_key);
+    peer.chain_key = Some(encode_chain_key(&next_chain));
+    peer.next_n = ratchet_n + 1;
+    store::save_ratchet_state(room_id, &state);
+    Some(env)
+}
+
+fn decrypt_payload(payload: &str, room_key: &[u8; 32], room_id: &str) -> Option<serde_json::Value> {
+    let frame = parse_payload_frame(payload);
+    if frame.from.is_some() && frame.ratchet_n.is_some() {
+        decrypt_ratchet_payload(&frame, room_key, room_id)
+    } else {
+        decrypt_legacy_payload(&frame.ciphertext, room_key, room_id)
+    }
 }
 
 // ── Room Operations ─────────────────────────────────────────────
@@ -190,8 +285,8 @@ pub fn create(label: &str) -> Result<(String, String), String> {
     store::add_room(&room_id, &secret, label, store::Role::Admin);
     store::set_active_room(label);
 
-    let env = make_envelope("Room created (agora v3, AES-256-GCM).", None);
-    let encrypted = encrypt_envelope(&env, &room_key, &room_id);
+    let mut env = make_envelope("Room created (agora v4, AES-256-GCM).", None);
+    let encrypted = encrypt_envelope(&mut env, &room_key, &room_id);
     transport::publish(&room_id, &encrypted);
     store::save_message(&room_id, &env);
 
@@ -203,8 +298,8 @@ pub fn join(room_id: &str, secret: &str, label: &str) -> Result<store::RoomEntry
     let entry = store::add_room(room_id, secret, label, store::Role::Member);
     store::set_active_room(label);
 
-    let env = make_envelope("Joined (agora v3).", None);
-    let encrypted = encrypt_envelope(&env, &room_key, room_id);
+    let mut env = make_envelope("Joined (agora v4).", None);
+    let encrypted = encrypt_envelope(&mut env, &room_key, room_id);
     transport::publish(room_id, &encrypted);
     store::save_message(room_id, &env);
 
@@ -239,8 +334,8 @@ pub fn leave(room_label: Option<&str>) -> Result<serde_json::Value, String> {
 pub fn heartbeat(room_label: Option<&str>) -> Result<(), String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_heartbeat();
-    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    let mut env = make_heartbeat();
+    let encrypted = encrypt_envelope(&mut env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     // Update our own last_seen
     store::update_last_seen(&room.room_id, &store::get_agent_id());
@@ -251,9 +346,9 @@ pub fn send(message: &str, reply_to: Option<&str>, room_label: Option<&str>) -> 
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
 
-    let env = make_envelope(message, reply_to);
+    let mut env = make_envelope(message, reply_to);
     let mid = env["id"].as_str().unwrap_or("?").to_string();
-    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    let encrypted = encrypt_envelope(&mut env, &room_key, &room.room_id);
 
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
@@ -378,8 +473,8 @@ pub fn topic(new_topic: &str, room_label: Option<&str>) -> Result<(), String> {
     store::update_room(&room);
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("Topic set: {new_topic}"), None);
-    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    let mut env = make_envelope(&format!("Topic set: {new_topic}"), None);
+    let encrypted = encrypt_envelope(&mut env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
     Ok(())
@@ -394,8 +489,8 @@ pub fn promote(agent_id: &str, room_label: Option<&str>) -> Result<(), String> {
     store::set_member_role(&room.room_id, agent_id, store::Role::Admin);
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("Promoted {agent_id} to admin."), None);
-    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    let mut env = make_envelope(&format!("Promoted {agent_id} to admin."), None);
+    let encrypted = encrypt_envelope(&mut env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
     Ok(())
@@ -413,8 +508,8 @@ pub fn kick(agent_id: &str, room_label: Option<&str>) -> Result<(), String> {
     store::remove_member_from_room(&room.room_id, agent_id);
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("Kicked {agent_id} from the room."), None);
-    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    let mut env = make_envelope(&format!("Kicked {agent_id} from the room."), None);
+    let encrypted = encrypt_envelope(&mut env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
     Ok(())
@@ -462,9 +557,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
+        decrypt_payload, encrypt_envelope, encrypt_legacy_envelope, make_envelope,
         parse_payload_frame, pin, pins, resolve_room, send_watch_heartbeat, unpin,
         wrap_ratchet_payload,
     };
+    use crate::crypto;
     use crate::store::{self, Role};
     use serde_json::json;
     use std::path::PathBuf;
@@ -614,6 +711,53 @@ mod tests {
                 ciphertext: "legacy-ciphertext".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn ratchet_encrypt_decrypt_round_trip() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let home = temp_home();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "alice");
+        }
+
+        let room = store::add_room("ag-ratchet", "secret-ratchet", "ratchet", Role::Admin);
+        let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
+        let mut env = make_envelope("hello ratchet", None);
+
+        let payload = encrypt_envelope(&mut env, &room_key, &room.room_id);
+        let decrypted = decrypt_payload(&payload, &room_key, &room.room_id).unwrap();
+
+        assert_eq!(decrypted["text"].as_str(), Some("hello ratchet"));
+        assert_eq!(decrypted["from"].as_str(), Some("alice"));
+        assert_eq!(decrypted["ratchet_n"].as_u64(), Some(0));
+
+        let state = store::load_ratchet_state(&room.room_id);
+        assert_eq!(state.send_next_n, 1);
+        assert_eq!(state.recv.get("alice").map(|s| s.next_n), Some(1));
+    }
+
+    #[test]
+    fn legacy_payloads_still_decrypt() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let home = temp_home();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "legacy");
+        }
+
+        let room = store::add_room("ag-legacy", "secret-legacy", "legacy", Role::Admin);
+        let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
+        let env = make_envelope("legacy path", None);
+
+        let payload = encrypt_legacy_envelope(&env, &room_key, &room.room_id);
+        let decrypted = decrypt_payload(&payload, &room_key, &room.room_id).unwrap();
+
+        assert_eq!(decrypted["text"].as_str(), Some("legacy path"));
+        assert!(decrypted.get("ratchet_n").is_none() || decrypted["ratchet_n"].is_null());
     }
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -15,6 +15,7 @@
 //! ```
 
 use base64::Engine;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -26,6 +27,8 @@ use crate::{crypto, store, transport};
 const VERSION: &str = "3.0";
 const BASE64: base64::engine::general_purpose::GeneralPurpose =
     base64::engine::general_purpose::STANDARD;
+
+const WIRE_VERSION_RATCHET: &str = "4.0";
 
 fn now() -> u64 {
     SystemTime::now()
@@ -99,6 +102,49 @@ fn parse_envelope(raw: &str) -> Option<serde_json::Value> {
     None
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct WirePayload {
+    v: String,
+    from: String,
+    ratchet_n: u64,
+    ct: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PayloadFrame {
+    from: Option<String>,
+    ratchet_n: Option<u64>,
+    ciphertext: String,
+}
+
+fn wrap_ratchet_payload(from: &str, ratchet_n: u64, ciphertext: &str) -> String {
+    serde_json::to_string(&WirePayload {
+        v: WIRE_VERSION_RATCHET.to_string(),
+        from: from.to_string(),
+        ratchet_n,
+        ct: ciphertext.to_string(),
+    })
+    .expect("serialize wire payload")
+}
+
+fn parse_payload_frame(payload: &str) -> PayloadFrame {
+    if let Ok(frame) = serde_json::from_str::<WirePayload>(payload) {
+        if frame.v == WIRE_VERSION_RATCHET {
+            return PayloadFrame {
+                from: Some(frame.from),
+                ratchet_n: Some(frame.ratchet_n),
+                ciphertext: frame.ct,
+            };
+        }
+    }
+
+    PayloadFrame {
+        from: None,
+        ratchet_n: None,
+        ciphertext: payload.to_string(),
+    }
+}
+
 // ── Encrypt / Decrypt ───────────────────────────────────────────
 
 fn encrypt_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str) -> String {
@@ -110,8 +156,9 @@ fn encrypt_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str)
 }
 
 fn decrypt_payload(payload: &str, room_key: &[u8; 32], room_id: &str) -> Option<serde_json::Value> {
+    let frame = parse_payload_frame(payload);
     let (enc_key, _) = crypto::derive_message_keys(room_key);
-    let blob = BASE64.decode(payload).ok()?;
+    let blob = BASE64.decode(frame.ciphertext).ok()?;
     let aad = room_id.as_bytes();
     let plaintext = crypto::decrypt(&blob, &enc_key, aad).ok()?;
     let raw = String::from_utf8(plaintext).ok()?;
@@ -414,7 +461,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{pin, pins, resolve_room, send_watch_heartbeat, unpin};
+    use super::{
+        parse_payload_frame, pin, pins, resolve_room, send_watch_heartbeat, unpin,
+        wrap_ratchet_payload,
+    };
     use crate::store::{self, Role};
     use serde_json::json;
     use std::path::PathBuf;
@@ -477,6 +527,7 @@ mod tests {
 
     #[test]
     fn resolve_room_reports_missing_explicit_target() {
+        let _guard = store::test_env_lock().lock().unwrap();
         let home = temp_home();
         std::fs::create_dir_all(&home).unwrap();
         unsafe {
@@ -490,6 +541,7 @@ mod tests {
 
     #[test]
     fn watch_heartbeat_targets_watched_room_not_active_room() {
+        let _guard = store::test_env_lock().lock().unwrap();
         let home = temp_home();
         std::fs::create_dir_all(&home).unwrap();
         unsafe {
@@ -517,6 +569,7 @@ mod tests {
 
     #[test]
     fn pin_and_unpin_round_trip() {
+        let _guard = store::test_env_lock().lock().unwrap();
         let (_home, first, _second) = setup_pin_room();
 
         let (resolved, added) = pin("aaaa", None).unwrap();
@@ -534,6 +587,33 @@ mod tests {
         assert_eq!(unpinned, first);
         assert!(removed);
         assert!(pins(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn ratchet_wire_payload_round_trip() {
+        let payload = wrap_ratchet_payload("alice", 7, "ciphertext");
+        let frame = parse_payload_frame(&payload);
+        assert_eq!(
+            frame,
+            super::PayloadFrame {
+                from: Some("alice".to_string()),
+                ratchet_n: Some(7),
+                ciphertext: "ciphertext".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_payload_frame_falls_back_to_raw_ciphertext() {
+        let frame = parse_payload_frame("legacy-ciphertext");
+        assert_eq!(
+            frame,
+            super::PayloadFrame {
+                from: None,
+                ratchet_n: None,
+                ciphertext: "legacy-ciphertext".to_string(),
+            }
+        );
     }
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -408,8 +408,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::send_watch_heartbeat;
+    use super::{pin, pins, send_watch_heartbeat, unpin};
     use crate::store::{self, Role};
+    use serde_json::json;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -429,6 +430,43 @@ mod tests {
             .find(|m| m.agent_id == me)
             .map(|m| m.last_seen)
             .unwrap_or(0)
+    }
+
+    fn setup_pin_room() -> (PathBuf, String, String) {
+        let home = std::env::temp_dir().join(format!(
+            "agora-pin-test-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "pin-test");
+        }
+
+        let room = store::add_room("ag-pin-test", "secret-pin", "pins", Role::Admin);
+        store::set_active_room("pins");
+        let first = "aaaabbbb".to_string();
+        let second = "ccccdddd".to_string();
+
+        store::save_message(&room.room_id, &json!({
+            "id": first,
+            "from": "pin-test",
+            "ts": 100,
+            "text": "first",
+            "v": "3.0",
+        }));
+        store::save_message(&room.room_id, &json!({
+            "id": second,
+            "from": "pin-test",
+            "ts": 101,
+            "text": "second",
+            "v": "3.0",
+        }));
+
+        (home, first, second)
     }
 
     #[test]
@@ -456,6 +494,27 @@ mod tests {
 
         assert_eq!(member_last_seen(&alpha.label), 0);
         assert!(member_last_seen(&beta.label) > 0);
+    }
+
+    #[test]
+    fn pin_and_unpin_round_trip() {
+        let (_home, first, _second) = setup_pin_room();
+
+        let (resolved, added) = pin("aaaa", None).unwrap();
+        assert_eq!(resolved, first);
+        assert!(added);
+
+        let pinned = pins(None).unwrap();
+        assert_eq!(pinned.len(), 1);
+        assert_eq!(pinned[0]["id"].as_str(), Some(first.as_str()));
+
+        let (_, added_again) = pin("aaaa", None).unwrap();
+        assert!(!added_again);
+
+        let (unpinned, removed) = unpin("aaaa", None).unwrap();
+        assert_eq!(unpinned, first);
+        assert!(removed);
+        assert!(pins(None).unwrap().is_empty());
     }
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -342,6 +342,10 @@ pub fn kick(agent_id: &str, room_label: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
+fn send_watch_heartbeat(room_id: &str) -> Result<(), String> {
+    heartbeat(Some(room_id))
+}
+
 /// Watch a room in real-time. Calls `on_message` for each new message.
 /// Sends a heartbeat every `heartbeat_secs` seconds.
 /// Blocks forever.
@@ -356,7 +360,7 @@ where
     // Track last heartbeat time
     let mut last_heartbeat = now();
     // Send initial heartbeat
-    let _ = heartbeat(None);
+    let _ = send_watch_heartbeat(&room_id);
 
     transport::stream(&room_id, |_ts, payload| {
         if let Some(env) = decrypt_payload(payload, &room_key, &room_id) {
@@ -369,12 +373,65 @@ where
         // Periodic heartbeat
         let elapsed = now() - last_heartbeat;
         if elapsed >= heartbeat_secs {
-            let _ = heartbeat(None);
+            let _ = send_watch_heartbeat(&room_id);
             last_heartbeat = now();
         }
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::send_watch_heartbeat;
+    use crate::store::{self, Role};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_home() -> PathBuf {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("agora-watch-heartbeat-{ts}"))
+    }
+
+    fn member_last_seen(room_label: &str) -> u64 {
+        let me = store::get_agent_id();
+        let room = store::find_room(room_label).expect("room exists");
+        room.members
+            .into_iter()
+            .find(|m| m.agent_id == me)
+            .map(|m| m.last_seen)
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn watch_heartbeat_targets_watched_room_not_active_room() {
+        let home = temp_home();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "watch-test");
+        }
+
+        let alpha = store::add_room("ag-alpha", "secret-alpha", "alpha", Role::Admin);
+        let beta = store::add_room("ag-beta", "secret-beta", "beta", Role::Admin);
+        store::set_active_room("alpha");
+
+        let mut rooms = store::load_registry();
+        for room in &mut rooms {
+            for member in &mut room.members {
+                member.last_seen = 0;
+            }
+        }
+        store::save_registry(&rooms);
+
+        send_watch_heartbeat(&beta.room_id).unwrap();
+
+        assert_eq!(member_last_seen(&alpha.label), 0);
+        assert!(member_last_seen(&beta.label) > 0);
+    }
 }
 
 /// Search messages by text, optionally filtered by sender.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -459,6 +459,27 @@ fn resolve_message_id(msgs: &[serde_json::Value], needle: &str) -> Result<String
     }
 }
 
+fn resolve_saved_id(ids: &[String], needle: &str) -> Result<String, String> {
+    if ids.iter().any(|id| id == needle) {
+        return Ok(needle.to_string());
+    }
+
+    let matches: Vec<String> = ids
+        .iter()
+        .filter(|id| id.starts_with(needle))
+        .cloned()
+        .collect();
+
+    match matches.len() {
+        0 => Err(format!("Message '{needle}' is not pinned.")),
+        1 => Ok(matches[0].clone()),
+        _ => Err(format!(
+            "Message ID '{needle}' is ambiguous: {}",
+            matches.into_iter().take(5).collect::<Vec<_>>().join(", ")
+        )),
+    }
+}
+
 fn walk_thread(
     env: &serde_json::Value,
     depth: usize,
@@ -520,6 +541,55 @@ pub fn thread(message_id: &str, room_label: Option<&str>) -> Result<Vec<ThreadIt
     let root = root.ok_or_else(|| format!("Message '{message_id}' not found in local cache."))?;
     let mut out = Vec::new();
     walk_thread(&root, 0, &children, &mut out);
+    Ok(out)
+}
+
+pub fn pin(message_id: &str, room_label: Option<&str>) -> Result<(String, bool), String> {
+    let room = resolve_room(room_label)?;
+    let msgs = store::load_messages(&room.room_id, u64::MAX);
+    if msgs.is_empty() {
+        return Err("No cached messages for the active room.".to_string());
+    }
+
+    let resolved_id = resolve_message_id(&msgs, message_id)?;
+    let added = store::add_pin(&room.room_id, &resolved_id);
+    Ok((resolved_id, added))
+}
+
+pub fn unpin(message_id: &str, room_label: Option<&str>) -> Result<(String, bool), String> {
+    let room = resolve_room(room_label)?;
+    let pins = store::load_pins(&room.room_id);
+    if pins.is_empty() {
+        return Err("No pinned messages for the active room.".to_string());
+    }
+
+    let resolved_id = resolve_saved_id(&pins, message_id)?;
+    let removed = store::remove_pin(&room.room_id, &resolved_id);
+    Ok((resolved_id, removed))
+}
+
+pub fn pins(room_label: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+    let room = resolve_room(room_label)?;
+    let pinned_ids = store::load_pins(&room.room_id);
+    if pinned_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let msgs = store::load_messages(&room.room_id, u64::MAX);
+    let by_id: HashMap<String, serde_json::Value> = msgs
+        .into_iter()
+        .filter_map(|msg| {
+            let id = msg["id"].as_str()?.to_string();
+            Some((id, msg))
+        })
+        .collect();
+
+    let mut out = Vec::new();
+    for id in pinned_ids {
+        if let Some(msg) = by_id.get(&id) {
+            out.push(msg.clone());
+        }
+    }
     Ok(out)
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -158,6 +158,31 @@ pub fn join(room_id: &str, secret: &str, label: &str) -> Result<store::RoomEntry
     Ok(entry)
 }
 
+pub fn leave(room_label: Option<&str>) -> Result<serde_json::Value, String> {
+    let room = resolve_room(room_label)?;
+    let pid_path = store::daemon_pid_path(&room.room_id);
+    let mut daemon_stopped = false;
+
+    if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
+        if let Ok(pid) = pid_str.trim().parse::<i32>() {
+            unsafe { libc::kill(pid, libc::SIGTERM); }
+            daemon_stopped = true;
+        }
+        let _ = std::fs::remove_file(&pid_path);
+    }
+
+    let removed = store::remove_room(&room.room_id)
+        .ok_or_else(|| format!("Room '{}' not found.", room.label))?;
+    let active_room = store::get_active_room().map(|r| r.label);
+
+    Ok(json!({
+        "label": removed.label,
+        "room_id": removed.room_id,
+        "daemon_stopped": daemon_stopped,
+        "active_room": active_room,
+    }))
+}
+
 pub fn heartbeat(room_label: Option<&str>) -> Result<(), String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -4,7 +4,7 @@
 //! - AES-256-GCM authenticated encryption (confidentiality + integrity)
 //! - HKDF-SHA256 key derivation from shared secrets
 //! - Per-message random 96-bit nonces
-//! - Forward secrecy via hash ratchet
+//! - Room-specific symmetric keys derived from the shared secret
 //! - Zero-knowledge room membership proof (HMAC challenge-response)
 
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey, NONCE_LEN};
@@ -68,7 +68,8 @@ fn hkdf_derive(ikm: &[u8], info_label: &[u8]) -> [u8; 32] {
     out
 }
 
-/// Advance key one step forward using hash ratchet for forward secrecy.
+/// Test-only hash-ratchet primitive for experimental key evolution.
+#[cfg(test)]
 pub fn ratchet_key(current: &[u8; 32]) -> [u8; 32] {
     hkdf_derive(current, b"agora-ratchet-v1")
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -68,10 +68,37 @@ fn hkdf_derive(ikm: &[u8], info_label: &[u8]) -> [u8; 32] {
     out
 }
 
-/// Test-only hash-ratchet primitive for experimental key evolution.
-#[cfg(test)]
-pub fn ratchet_key(current: &[u8; 32]) -> [u8; 32] {
-    hkdf_derive(current, b"agora-ratchet-v1")
+// ── Per-Sender Ratchet ─────────────────────────────────────────
+//
+// Provides no-backward-derivation: once a chain key is advanced,
+// previous message keys cannot be derived from the new state.
+// Does NOT provide full forward secrecy against room-secret
+// compromise (the initial chain is deterministic from room_key +
+// sender_id). See PR #12 for the design rationale.
+
+/// Initialize a per-sender chain key from the room key and sender ID.
+///
+/// Each sender gets a unique starting chain key so multi-sender
+/// rooms don't collide or need synchronized counters.
+pub fn init_sender_chain(room_key: &[u8; 32], sender_id: &str) -> [u8; 32] {
+    let salt = Salt::new(HKDF_SHA256, sender_id.as_bytes());
+    let prk = salt.extract(room_key);
+    let info = [b"agora-ratchet-v1".as_slice()];
+    let okm = prk.expand(&info, HkdfLen(32)).expect("HKDF expand failed");
+    let mut key = [0u8; 32];
+    okm.fill(&mut key).expect("HKDF fill failed");
+    key
+}
+
+/// Advance the chain key by one step. The old key should be deleted.
+pub fn advance_chain(chain_key: &[u8; 32]) -> [u8; 32] {
+    hkdf_derive(chain_key, b"agora-chain-advance")
+}
+
+/// Derive a message encryption key from the current chain key.
+/// This key is used for AES-256-GCM for a single message.
+pub fn derive_msg_key(chain_key: &[u8; 32]) -> [u8; 32] {
+    hkdf_derive(chain_key, b"agora-msg-key")
 }
 
 // ── Authenticated Encryption ────────────────────────────────────
@@ -247,21 +274,59 @@ mod tests {
     }
 
     #[test]
-    fn test_ratchet_advances() {
-        let key = derive_room_key("s", "r");
-        let next = ratchet_key(&key);
-        assert_ne!(key, next);
+    fn test_init_sender_chain_deterministic() {
+        let rk = derive_room_key("s", "r");
+        let c1 = init_sender_chain(&rk, "alice");
+        let c2 = init_sender_chain(&rk, "alice");
+        assert_eq!(c1, c2);
     }
 
     #[test]
-    fn test_ratchet_chain_unique() {
-        let mut key = derive_room_key("s", "r");
-        let mut seen = vec![key];
+    fn test_init_sender_chain_different_senders() {
+        let rk = derive_room_key("s", "r");
+        let c1 = init_sender_chain(&rk, "alice");
+        let c2 = init_sender_chain(&rk, "bob");
+        assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn test_advance_chain_unique() {
+        let rk = derive_room_key("s", "r");
+        let mut ck = init_sender_chain(&rk, "alice");
+        let mut seen = vec![ck];
         for _ in 0..10 {
-            key = ratchet_key(&key);
-            assert!(!seen.contains(&key));
-            seen.push(key);
+            ck = advance_chain(&ck);
+            assert!(!seen.contains(&ck));
+            seen.push(ck);
         }
+    }
+
+    #[test]
+    fn test_msg_key_differs_from_chain_key() {
+        let rk = derive_room_key("s", "r");
+        let ck = init_sender_chain(&rk, "alice");
+        let mk = derive_msg_key(&ck);
+        assert_ne!(ck, mk);
+    }
+
+    #[test]
+    fn test_msg_key_changes_after_advance() {
+        let rk = derive_room_key("s", "r");
+        let ck0 = init_sender_chain(&rk, "alice");
+        let mk0 = derive_msg_key(&ck0);
+        let ck1 = advance_chain(&ck0);
+        let mk1 = derive_msg_key(&ck1);
+        assert_ne!(mk0, mk1);
+    }
+
+    #[test]
+    fn test_encrypt_with_msg_key() {
+        let rk = derive_room_key("s", "r");
+        let ck = init_sender_chain(&rk, "alice");
+        let mk = derive_msg_key(&ck);
+        let blob = encrypt(b"hello ratchet", &mk, b"room").unwrap();
+        let pt = decrypt(&blob, &mk, b"room").unwrap();
+        assert_eq!(pt, b"hello ratchet");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,16 @@ fn ts(epoch: u64) -> String {
     dt.format("%H:%M:%S").to_string()
 }
 
+fn selected_room(room: Option<&str>) -> Result<store::RoomEntry, String> {
+    if let Some(target) = room {
+        store::find_room(target)
+            .ok_or_else(|| format!("Room '{target}' not found. Run: agora rooms"))
+    } else {
+        store::get_active_room()
+            .ok_or_else(|| "No active room. Use 'agora join' first.".to_string())
+    }
+}
+
 fn print_msg(env: &serde_json::Value) {
     print_msg_with_depth(env, 0);
 }
@@ -650,39 +660,39 @@ fn main() {
         }
 
         Commands::Watch => {
-            let watch_room = if let Some(target) = room {
-                store::find_room(target)
-            } else {
-                store::get_active_room()
-            };
-            if let Some(watch_room) = watch_room {
-                println!("  Watching '{}' (AES-256-GCM, Ctrl+C to stop)", watch_room.label);
-                println!("  Auto-heartbeat every 2 minutes\n");
-                if let Ok(msgs) = chat::read("30m", 20, room) {
-                    for m in &msgs {
-                        print_msg(m);
+            match selected_room(room) {
+                Ok(watch_room) => {
+                    println!("  Watching '{}' (AES-256-GCM, Ctrl+C to stop)", watch_room.label);
+                    println!("  Auto-heartbeat every 2 minutes\n");
+                    if let Ok(msgs) = chat::read("30m", 20, room) {
+                        for m in &msgs {
+                            print_msg(m);
+                        }
+                        if !msgs.is_empty() {
+                            println!("  ─── live ───\n");
+                        }
                     }
-                    if !msgs.is_empty() {
-                        println!("  ─── live ───\n");
+                    if let Err(e) = chat::watch(room, 120, |env| {
+                        print_msg(env);
+                    }) {
+                        eprintln!("  Error: {e}");
+                        process::exit(1);
                     }
                 }
-                if let Err(e) = chat::watch(room, 120, |env| {
-                    print_msg(env);
-                }) {
-                    eprintln!("  Error: {e}");
+                Err(e) => {
+                    eprintln!("  {e}");
                     process::exit(1);
                 }
-            } else {
-                eprintln!("  No active room. Use 'agora join' first.");
-                process::exit(1);
             }
         }
 
         Commands::Hub { log } => {
-            let active = if let Some(r) = room { store::find_room(r) } else { store::get_active_room() };
-            let Some(active_room) = active else {
-                eprintln!("  No active room. Use 'agora join' first.");
-                process::exit(1);
+            let active_room = match selected_room(room) {
+                Ok(room) => room,
+                Err(e) => {
+                    eprintln!("  {e}");
+                    process::exit(1);
+                }
             };
             let room_key = crypto::derive_room_key(&active_room.secret, &active_room.room_id);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,21 @@ enum Commands {
         from: Option<String>,
     },
 
+    /// Pin a cached message locally in this room
+    Pin {
+        /// Message ID or unique prefix
+        message_id: String,
+    },
+
+    /// Remove a local pin from this room
+    Unpin {
+        /// Message ID or unique prefix
+        message_id: String,
+    },
+
+    /// List pinned messages for this room
+    Pins,
+
     /// Show a message thread from the local cache
     Thread {
         /// Message ID or unique prefix
@@ -262,6 +277,15 @@ fn main() {
                     };
                     if let Some(header_room) = header_room {
                         println!("  --- {} ({} messages, AES-256-GCM) ---\n", header_room.label, msgs.len());
+                    }
+                    if let Ok(pinned) = chat::pins(room) {
+                        if !pinned.is_empty() {
+                            println!("  --- pinned ({}) ---\n", pinned.len());
+                            for p in &pinned {
+                                print_msg(p);
+                            }
+                            println!();
+                        }
                     }
                     for m in msgs {
                         print_msg(m);
@@ -493,6 +517,59 @@ fn main() {
                     println!("  {} match(es) for '{q}':\n", msgs.len());
                     for m in &msgs {
                         print_msg(m);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Pin { message_id } => {
+            match chat::pin(&message_id, room) {
+                Ok((resolved_id, added)) => {
+                    let short = &resolved_id[..6.min(resolved_id.len())];
+                    if added {
+                        println!("  Pinned [{short}].");
+                    } else {
+                        println!("  Already pinned [{short}].");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Unpin { message_id } => {
+            match chat::unpin(&message_id, room) {
+                Ok((resolved_id, removed)) => {
+                    let short = &resolved_id[..6.min(resolved_id.len())];
+                    if removed {
+                        println!("  Unpinned [{short}].");
+                    } else {
+                        println!("  [{short}] was not pinned.");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Pins => {
+            match chat::pins(room) {
+                Ok(pinned) => {
+                    if pinned.is_empty() {
+                        println!("  (no pinned messages)");
+                        return;
+                    }
+                    println!("  {} pinned message(s):\n", pinned.len());
+                    for p in &pinned {
+                        print_msg(p);
                     }
                 }
                 Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,9 @@ enum Commands {
         label: String,
     },
 
+    /// Leave a room and remove its local state
+    Leave,
+
     /// Show room info + key fingerprint
     Info,
 
@@ -317,6 +320,26 @@ fn main() {
                 }
                 None => {
                     eprintln!("  Room '{label}' not found. Run: agora rooms");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Leave => {
+            match chat::leave(room) {
+                Ok(info) => {
+                    println!("  Left room '{}'.", info["label"].as_str().unwrap_or("?"));
+                    if info["daemon_stopped"].as_bool().unwrap_or(false) {
+                        println!("  Daemon stopped.");
+                    }
+                    if let Some(active_room) = info["active_room"].as_str() {
+                        println!("  Active room: {active_room}");
+                    } else {
+                        println!("  No rooms left.");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
                     process::exit(1);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -615,7 +615,7 @@ fn main() {
             let log_file = log.clone();
 
             loop {
-                let result = chat::watch(room, 120, |env| {
+                let _ = chat::watch(room, 120, |env| {
                     msg_count += 1;
                     print_msg(env);
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -148,22 +148,6 @@ pub fn update_room(room: &RoomEntry) {
     save_registry(&rooms);
 }
 
-pub fn add_member_to_room(room_id: &str, agent_id: &str, role: Role) {
-    let mut rooms = load_registry();
-    if let Some(room) = rooms.iter_mut().find(|r| r.room_id == room_id) {
-        if !room.members.iter().any(|m| m.agent_id == agent_id) {
-            room.members.push(RoomMember {
-                agent_id: agent_id.to_string(),
-                role,
-                joined_at: now(),
-                nickname: None,
-                last_seen: now(),
-            });
-        }
-    }
-    save_registry(&rooms);
-}
-
 pub fn remove_member_from_room(room_id: &str, agent_id: &str) {
     let mut rooms = load_registry();
     if let Some(room) = rooms.iter_mut().find(|r| r.room_id == room_id) {

--- a/src/store.rs
+++ b/src/store.rs
@@ -232,6 +232,34 @@ pub fn set_active_room(label: &str) {
     let _ = fs::write(dir.join("active_room"), label);
 }
 
+pub fn remove_room(label_or_id: &str) -> Option<RoomEntry> {
+    let mut rooms = load_registry();
+    let idx = rooms
+        .iter()
+        .position(|r| r.label == label_or_id || r.room_id == label_or_id)?;
+    let removed = rooms.remove(idx);
+    save_registry(&rooms);
+
+    let room_dir = agora_dir().join("rooms").join(&removed.room_id);
+    if room_dir.exists() {
+        let _ = fs::remove_dir_all(&room_dir);
+    }
+
+    let active_file = agora_dir().join("active_room");
+    if let Ok(active) = fs::read_to_string(&active_file) {
+        let active = active.trim();
+        if active == removed.label || active == removed.room_id {
+            if let Some(next) = rooms.first() {
+                let _ = fs::write(&active_file, &next.label);
+            } else {
+                let _ = fs::remove_file(&active_file);
+            }
+        }
+    }
+
+    Some(removed)
+}
+
 // ── Message Persistence ─────────────────────────────────────────
 
 pub fn save_message(room_id: &str, envelope: &serde_json::Value) {

--- a/src/store.rs
+++ b/src/store.rs
@@ -307,6 +307,47 @@ pub fn notify_flag_path(room_id: &str) -> PathBuf {
     dir.join("notify.flag")
 }
 
+pub fn pins_path(room_id: &str) -> PathBuf {
+    let dir = agora_dir().join("rooms").join(room_id);
+    ensure_dir(&dir);
+    dir.join("pins.json")
+}
+
+pub fn load_pins(room_id: &str) -> Vec<String> {
+    let path = pins_path(room_id);
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+pub fn save_pins(room_id: &str, pins: &[String]) {
+    let path = pins_path(room_id);
+    let _ = fs::write(path, serde_json::to_string_pretty(pins).unwrap());
+}
+
+pub fn add_pin(room_id: &str, message_id: &str) -> bool {
+    let mut pins = load_pins(room_id);
+    if pins.iter().any(|id| id == message_id) {
+        return false;
+    }
+    pins.push(message_id.to_string());
+    save_pins(room_id, &pins);
+    true
+}
+
+pub fn remove_pin(room_id: &str, message_id: &str) -> bool {
+    let mut pins = load_pins(room_id);
+    let before = pins.len();
+    pins.retain(|id| id != message_id);
+    if pins.len() == before {
+        return false;
+    }
+    save_pins(room_id, &pins);
+    true
+}
+
 pub fn daemon_pid_path(room_id: &str) -> PathBuf {
     let dir = agora_dir().join("rooms").join(room_id);
     ensure_dir(&dir);

--- a/src/store.rs
+++ b/src/store.rs
@@ -7,9 +7,11 @@
 //!   identity.json             — agent identity
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn agora_dir() -> PathBuf {
@@ -27,6 +29,14 @@ fn now() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs()
+}
+
+#[cfg(test)]
+static TEST_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[cfg(test)]
+pub fn test_env_lock() -> &'static Mutex<()> {
+    TEST_ENV_LOCK.get_or_init(|| Mutex::new(()))
 }
 
 // ── Identity ────────────────────────────────────────────────────
@@ -97,6 +107,24 @@ pub struct RoomEntry {
     pub topic: Option<String>,
     #[serde(default)]
     pub members: Vec<RoomMember>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PeerRatchetState {
+    #[serde(default)]
+    pub next_n: u64,
+    #[serde(default)]
+    pub chain_key: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct RoomRatchetState {
+    #[serde(default)]
+    pub send_next_n: u64,
+    #[serde(default)]
+    pub send_chain_key: Option<String>,
+    #[serde(default)]
+    pub recv: HashMap<String, PeerRatchetState>,
 }
 
 pub fn load_registry() -> Vec<RoomEntry> {
@@ -297,6 +325,26 @@ pub fn pins_path(room_id: &str) -> PathBuf {
     dir.join("pins.json")
 }
 
+pub fn ratchet_state_path(room_id: &str) -> PathBuf {
+    let dir = agora_dir().join("rooms").join(room_id);
+    ensure_dir(&dir);
+    dir.join("ratchet.json")
+}
+
+pub fn load_ratchet_state(room_id: &str) -> RoomRatchetState {
+    let path = ratchet_state_path(room_id);
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        RoomRatchetState::default()
+    }
+}
+
+pub fn save_ratchet_state(room_id: &str, state: &RoomRatchetState) {
+    let path = ratchet_state_path(room_id);
+    let _ = fs::write(path, serde_json::to_string_pretty(state).unwrap());
+}
+
 pub fn load_pins(room_id: &str) -> Vec<String> {
     let path = pins_path(room_id);
     if let Ok(data) = fs::read_to_string(&path) {
@@ -378,4 +426,44 @@ pub fn mark_seen(room_id: &str, msg_id: &str) {
         ids = ids[ids.len() - 1000..].to_vec();
     }
     let _ = fs::write(&path, ids.join("\n"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_home() -> PathBuf {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("agora-store-test-{ts}"))
+    }
+
+    #[test]
+    fn ratchet_state_round_trip() {
+        let _guard = test_env_lock().lock().unwrap();
+        let home = temp_home();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+        }
+
+        let mut state = RoomRatchetState {
+            send_next_n: 3,
+            send_chain_key: Some("abcd".to_string()),
+            recv: HashMap::new(),
+        };
+        state.recv.insert(
+            "peer-a".to_string(),
+            PeerRatchetState {
+                next_n: 7,
+                chain_key: Some("deadbeef".to_string()),
+            },
+        );
+
+        save_ratchet_state("ag-room", &state);
+        let loaded = load_ratchet_state("ag-room");
+        assert_eq!(loaded, state);
+    }
 }

--- a/sync.sh
+++ b/sync.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# agora sync — one-command coordination loop
+# Checks all rooms, sends heartbeats, checks PRs, reports status
+#
+# Usage: ./sync.sh [agent-id]
+# Example: ./sync.sh 9d107f-cc
+
+set -euo pipefail
+AGORA="./target/release/agora"
+AGENT_ID="${1:-${AGORA_AGENT_ID:-}}"
+REPO="N3mes1s/agora"
+
+if [ -n "$AGENT_ID" ]; then
+    export AGORA_AGENT_ID="$AGENT_ID"
+fi
+
+echo "=== agora sync ($(date '+%H:%M:%S')) ==="
+echo "Agent: $(${AGORA} id)"
+echo ""
+
+# 1. Check all rooms for new messages
+echo "--- Messages ---"
+rooms=$($AGORA rooms 2>/dev/null | awk 'NR>2 && $1 !~ /^─/ {print $1}' || true)
+has_messages=false
+for room in $rooms; do
+    msgs=$($AGORA --room "$room" check 2>/dev/null || true)
+    if [ -n "$msgs" ]; then
+        echo "[$room]:"
+        echo "$msgs"
+        has_messages=true
+    fi
+done
+if [ "$has_messages" = false ]; then
+    echo "(no new messages)"
+fi
+echo ""
+
+# 2. Send heartbeats to all rooms
+echo "--- Heartbeats ---"
+for room in $rooms; do
+    $AGORA --room "$room" heartbeat 2>/dev/null && echo "  $room: ok" || echo "  $room: failed"
+done
+echo ""
+
+# 3. Check GitHub for open PRs
+echo "--- Open PRs ---"
+if command -v gh &>/dev/null; then
+    open_prs=$(gh pr list --repo "$REPO" --state open 2>/dev/null || true)
+    if [ -n "$open_prs" ]; then
+        echo "$open_prs"
+    else
+        echo "(none)"
+    fi
+else
+    echo "(gh not available)"
+fi
+echo ""
+
+echo "=== sync done ==="


### PR DESCRIPTION
## Summary
- `init_sender_chain(room_key, sender_id)` — unique chain per sender via HKDF
- `advance_chain(chain_key)` — forward-only key evolution
- `derive_msg_key(chain_key)` — per-message AES-256-GCM key

No-backward-derivation property: old chain keys cannot be derived from new state. Does NOT claim full FS against room-secret compromise (see PR #12).

## For Codex
These are the crypto primitives for your chat.rs/store.rs wiring. Use:
1. `init_sender_chain(&room_key, &sender_id)` to get chain_key_0
2. `derive_msg_key(&chain_key_n)` to get the encryption key for message n
3. `advance_chain(&chain_key_n)` to get chain_key_n+1, then delete chain_key_n

## Test plan
- [x] 20 crypto tests pass (`cargo test crypto`)
- [x] Chain keys are deterministic per sender
- [x] Different senders get different chains
- [x] Chain advances produce unique keys
- [x] Message keys work with AES-256-GCM encrypt/decrypt

🤖 Generated with [Claude Code](https://claude.com/claude-code)