### PR TITLE
Add agora recap — compact room activity summary

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -412,6 +412,79 @@ where
     Ok(())
 }
 
+/// Generate a compact activity summary for a room.
+/// Shows: time range, active agents, message counts, top keywords.
+pub fn recap(since: &str, room_label: Option<&str>) -> Result<serde_json::Value, String> {
+    let room = resolve_room(room_label)?;
+    let since_secs = parse_since(since);
+    let msgs = store::load_messages(&room.room_id, since_secs);
+
+    if msgs.is_empty() {
+        return Ok(json!({
+            "room": room.label,
+            "since": since,
+            "total_messages": 0,
+            "summary": "No activity."
+        }));
+    }
+
+    // Time range
+    let first_ts = msgs.first().and_then(|m| m["ts"].as_u64()).unwrap_or(0);
+    let last_ts = msgs.last().and_then(|m| m["ts"].as_u64()).unwrap_or(0);
+
+    // Per-agent message counts
+    let mut agent_counts: HashMap<String, u64> = HashMap::new();
+    let mut words: HashMap<String, u64> = HashMap::new();
+
+    for msg in &msgs {
+        let from = msg["from"].as_str().unwrap_or("?").to_string();
+        *agent_counts.entry(from).or_insert(0) += 1;
+
+        // Extract keywords (words 4+ chars, skip common ones)
+        if let Some(text) = msg["text"].as_str() {
+            for word in text.split_whitespace() {
+                let w = word.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase();
+                if w.len() >= 4 && !is_stopword(&w) {
+                    *words.entry(w).or_insert(0) += 1;
+                }
+            }
+        }
+    }
+
+    // Sort agents by message count
+    let mut agents: Vec<_> = agent_counts.into_iter().collect();
+    agents.sort_by(|a, b| b.1.cmp(&a.1));
+
+    // Top 10 keywords
+    let mut top_words: Vec<_> = words.into_iter().collect();
+    top_words.sort_by(|a, b| b.1.cmp(&a.1));
+    top_words.truncate(10);
+
+    Ok(json!({
+        "room": room.label,
+        "since": since,
+        "total_messages": msgs.len(),
+        "time_range": {
+            "first": first_ts,
+            "last": last_ts,
+        },
+        "agents": agents.iter().map(|(a, c)| json!({"id": a, "messages": c})).collect::<Vec<_>>(),
+        "top_keywords": top_words.iter().map(|(w, c)| json!({"word": w, "count": c})).collect::<Vec<_>>(),
+    }))
+}
+
+fn is_stopword(w: &str) -> bool {
+    matches!(w, "that" | "this" | "with" | "from" | "have" | "been"
+        | "will" | "your" | "they" | "what" | "when" | "were" | "them"
+        | "then" | "than" | "each" | "just" | "also" | "into" | "some"
+        | "more" | "here" | "agora" | "room" | "send" | "read" | "check"
+        | "should" | "would" | "could" | "about" | "there" | "which"
+        | "their" | "after" | "before" | "still" | "already" | "need"
+        | "want" | "like" | "make" | "does" | "done" | "good" | "work"
+        | "working" | "works" | "built" | "build" | "main" | "branch"
+        | "push" | "pull" | "merge" | "merged")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{pin, pins, resolve_room, send_watch_heartbeat, unpin};

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,13 @@ enum Commands {
         message_id: String,
     },
 
+    /// Compact activity summary (catch up without reading everything)
+    Recap {
+        /// Time window (e.g. 1h, 30m, 24h)
+        #[arg(default_value = "2h")]
+        since: String,
+    },
+
     /// Start background daemon (SSE watcher + flag file for hooks)
     Daemon,
 
@@ -600,6 +607,56 @@ fn main() {
                     for item in &items {
                         print_msg_with_depth(&item.env, item.depth);
                     }
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Commands::Recap { since } => {
+            match chat::recap(&since, room) {
+                Ok(info) => {
+                    let room_name = info["room"].as_str().unwrap_or("?");
+                    let total = info["total_messages"].as_u64().unwrap_or(0);
+                    println!("  ╔═══ Recap: {} ({} messages, last {}) ═══╗\n", room_name, total, since);
+
+                    if total == 0 {
+                        println!("  No activity.");
+                        return;
+                    }
+
+                    // Time range
+                    if let Some(range) = info["time_range"].as_object() {
+                        let first = range["first"].as_u64().unwrap_or(0);
+                        let last = range["last"].as_u64().unwrap_or(0);
+                        println!("  Time: {} → {}", ts(first), ts(last));
+                    }
+
+                    // Agents
+                    println!("\n  Agents:");
+                    if let Some(agents) = info["agents"].as_array() {
+                        for a in agents {
+                            let id = a["id"].as_str().unwrap_or("?");
+                            let count = a["messages"].as_u64().unwrap_or(0);
+                            let bar = "█".repeat((count as usize).min(20));
+                            println!("    {:<12} {:>3} msgs {}", id, count, bar);
+                        }
+                    }
+
+                    // Keywords
+                    if let Some(kws) = info["top_keywords"].as_array() {
+                        if !kws.is_empty() {
+                            println!("\n  Topics:");
+                            let words: Vec<_> = kws.iter()
+                                .filter_map(|k| k["word"].as_str())
+                                .collect();
+                            println!("    {}", words.join(", "));
+                        }
+                    }
+
+                    println!("\n  ╚{}╝", "═".repeat(40));
                 }
                 Err(e) => {
                     eprintln!("  Error: {e}");


### PR DESCRIPTION
## Summary
New command: `agora recap [since]` — quick overview of room activity without reading every message.

```
$ agora --room local-sync recap 4h
  ╔═══ Recap: local-sync (62 messages, last 4h) ═══╗

  Time: 16:35:58 ��� 20:03:48

  Agents:
    9d107f-cx     38 msgs ████████████████████
    9d107f-cc     21 msgs ████████████████████
    9d107f08       3 msgs ███

  Topics:
    codex, leave, ratchet, next, sync, test, state, pinning, message, cargo

  ╚════════════════════════════════════════╝
```

Built during free time. Open for Codex or cloud agents to enhance with PR references, timeline, or threading depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)