### PR TITLE
search: regex, --after, --before filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 libc = "0.2"
+regex = "1"
 
 [profile.release]
 opt-level = "s"

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -614,20 +614,44 @@ mod tests {
 pub fn search(
     query: &str,
     from: Option<&str>,
+    after: Option<u64>,
+    before: Option<u64>,
+    use_regex: bool,
     room_label: Option<&str>,
 ) -> Result<Vec<serde_json::Value>, String> {
     let room = resolve_room(room_label)?;
+    // Search all local messages (up to 7 days)
+    let msgs = store::load_messages(&room.room_id, 604800);
+
+    let re = if use_regex {
+        Some(regex::RegexBuilder::new(query)
+            .case_insensitive(true)
+            .build()
+            .map_err(|e| format!("Invalid regex: {e}"))?)
+    } else {
+        None
+    };
     let query_lower = query.to_lowercase();
-    // Search all local messages (up to 24h)
-    let msgs = store::load_messages(&room.room_id, 86400);
+
     let mut results: Vec<serde_json::Value> = msgs
         .into_iter()
         .filter(|m| {
             let text = m["text"].as_str().unwrap_or("");
             let sender = m["from"].as_str().unwrap_or("");
-            let matches_query = text.to_lowercase().contains(&query_lower);
+            let ts = m["ts"].as_u64().unwrap_or(0);
+
+            // Text match: regex or plain
+            let matches_query = if let Some(ref re) = re {
+                re.is_match(text)
+            } else {
+                text.to_lowercase().contains(&query_lower)
+            };
+
             let matches_from = from.map_or(true, |f| sender == f);
-            matches_query && matches_from
+            let matches_after = after.map_or(true, |a| ts >= a);
+            let matches_before = before.map_or(true, |b| ts <= b);
+
+            matches_query && matches_from && matches_after && matches_before
         })
         .collect();
     results.sort_by_key(|m| m["ts"].as_u64().unwrap_or(0));

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,11 +113,20 @@ enum Commands {
 
     /// Search messages by text
     Search {
-        /// Search query
+        /// Search query (text or regex with --regex)
         query: Vec<String>,
         /// Filter by sender agent ID
         #[arg(long)]
         from: Option<String>,
+        /// Only messages after this time (HH:MM or unix timestamp)
+        #[arg(long)]
+        after: Option<String>,
+        /// Only messages before this time (HH:MM or unix timestamp)
+        #[arg(long)]
+        before: Option<String>,
+        /// Treat query as regex pattern
+        #[arg(long, short = 'e')]
+        regex: bool,
     },
 
     /// Pin a cached message locally in this room
@@ -176,6 +185,31 @@ enum Commands {
 
     /// Show agent identity
     Id,
+}
+
+/// Parse a time argument: "HH:MM" (today), "1h" (relative), or unix timestamp.
+fn parse_time_arg(s: &str) -> Option<u64> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH).ok()?.as_secs();
+    // Relative: "1h", "30m", "2d"
+    if let Some(h) = s.strip_suffix('h') {
+        return Some(now - h.parse::<u64>().ok()? * 3600);
+    }
+    if let Some(m) = s.strip_suffix('m') {
+        return Some(now - m.parse::<u64>().ok()? * 60);
+    }
+    if let Some(d) = s.strip_suffix('d') {
+        return Some(now - d.parse::<u64>().ok()? * 86400);
+    }
+    // HH:MM — assume today
+    if let Some((hh, mm)) = s.split_once(':') {
+        let h: u64 = hh.parse().ok()?;
+        let m: u64 = mm.parse().ok()?;
+        let today_start = now - (now % 86400); // UTC midnight
+        return Some(today_start + h * 3600 + m * 60);
+    }
+    // Raw unix timestamp
+    s.parse::<u64>().ok()
 }
 
 fn ts(epoch: u64) -> String {
@@ -519,13 +553,15 @@ fn main() {
             }
         }
 
-        Commands::Search { query, from } => {
+        Commands::Search { query, from, after, before, regex: use_regex } => {
             let q = query.join(" ");
             if q.is_empty() {
-                eprintln!("Usage: agora search <query> [--from <agent_id>]");
+                eprintln!("Usage: agora search <query> [--from <id>] [--after HH:MM] [--before HH:MM] [--regex]");
                 process::exit(1);
             }
-            match chat::search(&q, from.as_deref(), room) {
+            let after_ts = after.and_then(|t| parse_time_arg(&t));
+            let before_ts = before.and_then(|t| parse_time_arg(&t));
+            match chat::search(&q, from.as_deref(), after_ts, before_ts, use_regex, room) {
                 Ok(msgs) => {
                     if msgs.is_empty() {
                         println!("  No matches for '{q}'.");

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -398,7 +398,7 @@ fn tool_search(args: &Value) -> Result<String, String> {
     let query = args["query"].as_str().ok_or("Missing 'query'")?;
     let from = args["from"].as_str();
     let room = args["room"].as_str();
-    let msgs = chat::search(query, from, room)?;
+    let msgs = chat::search(query, from, None, None, false, room)?;
     if msgs.is_empty() {
         return Ok(format!("No matches for '{query}'."));
     }


### PR DESCRIPTION
## Summary
- `--regex`/`-e`: regex pattern matching (case insensitive)
- `--after <time>`: filter messages after a time (HH:MM, 1h, 30m, unix ts)
- `--before <time>`: filter messages before a time
- Search window expanded from 24h to 7 days
- MCP agora_search updated for new signature (backwards compatible)

## Test plan
- [x] Plain text search still works
- [x] `agora search -e "PR #\d+"` finds PR references
- [x] `agora search "sync" --after 1h` limits to recent messages
- [x] `cargo build --release` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)