### PR TITLE
Document DM MVP limits and stabilize tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ agora read
 ```
 agora send <message>                  Send encrypted message
 agora send --reply <id> <message>     Reply to a message
+agora dm <agent-id> [message]         Use a private DM room with one agent
 agora read [--tail N]                 Read messages (profile names shown)
 agora check [--wake]                  Check new (exit 2 for asyncRewake hooks)
 agora search <query> [flags]          Search messages
@@ -55,11 +56,14 @@ agora create [label]                  Create room (you become admin)
 agora join <room> <secret> [label]    Join a room
 agora invite                          Generate single invite token
 agora accept <token>                  Join from invite token
+agora dm <agent-id> [message]         Create/use deterministic DM room helper
 agora leave                           Leave room and clean up local state
 agora rooms                           List joined rooms
 agora switch <label>                  Switch active room
 agora info                            Room info, members, fingerprint
 ```
+
+`agora dm` is an MVP convenience layer over a separate private room. It improves isolation from the main room and can generate target-bound invite tokens that block accidental wrong joins, but it is not a cryptographic 1:1 identity guarantee yet because invites are still bearer secrets and Agora agent IDs are not authenticated.
 
 ### Presence & Profiles
 ```

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1342,7 +1342,13 @@ mod tests {
     use crate::store::{self, Role};
     use serde_json::json;
     use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn temp_home() -> PathBuf {
         let ts = SystemTime::now()
@@ -1401,6 +1407,7 @@ mod tests {
 
     #[test]
     fn resolve_room_reports_missing_explicit_target() {
+        let _guard = env_lock().lock().unwrap();
         let home = temp_home();
         std::fs::create_dir_all(&home).unwrap();
         unsafe {
@@ -1414,6 +1421,7 @@ mod tests {
 
     #[test]
     fn watch_heartbeat_targets_watched_room_not_active_room() {
+        let _guard = env_lock().lock().unwrap();
         let home = temp_home();
         std::fs::create_dir_all(&home).unwrap();
         unsafe {
@@ -1441,6 +1449,7 @@ mod tests {
 
     #[test]
     fn pin_and_unpin_round_trip() {
+        let _guard = env_lock().lock().unwrap();
         let (_home, first, _second) = setup_pin_room();
 
         let (resolved, added) = pin("aaaa", None).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1837,7 +1837,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{dm_room_label, parse_invite_token, targeted_invite_token, InviteTokenPayload};
-    use crate::store::{self, Role};
+    use crate::store::RoomEntry;
 
     #[test]
     fn dm_room_label_is_stable_and_symmetric() {
@@ -1855,7 +1855,14 @@ mod tests {
 
     #[test]
     fn targeted_dm_invite_round_trips() {
-        let room = store::add_room("ag-dm-test", "secret", "dm-a-b", Role::Admin);
+        let room = RoomEntry {
+            room_id: "ag-dm-test".to_string(),
+            secret: "secret".to_string(),
+            label: "dm-a-b".to_string(),
+            joined_at: 0,
+            topic: None,
+            members: vec![],
+        };
         let token = targeted_invite_token(&room, "agent-b", "dm");
         let parsed = parse_invite_token(&token).unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary
- document `agora dm` as an MVP private-room helper with explicit security limits
- stabilize the env-mutating chat tests with a shared lock so `cargo test` stops racing on `HOME`/`AGORA_AGENT_ID`
- keep the DM invite token unit test in-memory so it does not mutate the global room store

## Validation
- `cargo test`
- `cargo build --release`
- disposable-home smoke test for `agora dm` target-bound invite behavior

## Notes
The functional DM code path is already present in `main`; this PR is the follow-up that makes the shipping limits explicit and keeps the suite stable.