### PR TITLE
[codex] Add message signing with TOFU verification

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -161,16 +161,86 @@ fn encrypt_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str)
     let plaintext = serde_json::to_string(env).unwrap();
     let aad = room_id.as_bytes();
     let blob = crypto::encrypt(plaintext.as_bytes(), &enc_key, aad).expect("encrypt failed");
-    BASE64.encode(&blob)
+    let payload = BASE64.encode(&blob);
+    let from = env["from"].as_str().unwrap_or("");
+
+    let pkcs8 = store::load_or_create_signing_keypair(from).expect("signing key load failed");
+    let signing_pubkey = BASE64
+        .encode(crypto::signing_public_key(&pkcs8).expect("signing pubkey derivation failed"));
+    store::trust_signing_key(from, &signing_pubkey);
+
+    let signing_input = signing_message_bytes(room_id, from, &signing_pubkey, &payload);
+    let sig = BASE64.encode(
+        crypto::sign_message(&pkcs8, &signing_input).expect("message signing failed")
+    );
+
+    serde_json::to_string(&SignedWirePayload {
+        v: SIGNED_WIRE_VERSION.to_string(),
+        from: from.to_string(),
+        payload,
+        signing_pubkey,
+        sig,
+    })
+    .unwrap()
+}
+
+fn decrypt_signed_payload(raw: &str, room_key: &[u8; 32], room_id: &str) -> Option<serde_json::Value> {
+    let wire = serde_json::from_str::<SignedWirePayload>(raw).ok()?;
+    let signing_input =
+        signing_message_bytes(room_id, &wire.from, &wire.signing_pubkey, &wire.payload);
+    let public_key = BASE64.decode(&wire.signing_pubkey).ok()?;
+    let sig = BASE64.decode(&wire.sig).ok()?;
+
+    if !crypto::verify_message_signature(&public_key, &signing_input, &sig) {
+        eprintln!(
+            "  [warn] dropped message from '{}' in room '{}' due to invalid signature",
+            wire.from, room_id
+        );
+        return None;
+    }
+
+    if let Some(trusted) = store::get_trusted_signing_key(&wire.from) {
+        if trusted != wire.signing_pubkey {
+            eprintln!(
+                "  [warn] dropped message from '{}' in room '{}' due to signing key mismatch",
+                wire.from, room_id
+            );
+            return None;
+        }
+    } else {
+        store::trust_signing_key(&wire.from, &wire.signing_pubkey);
+    }
+
+    let (enc_key, _) = crypto::derive_message_keys(room_key);
+    let blob = BASE64.decode(&wire.payload).ok()?;
+    let aad = room_id.as_bytes();
+    let plaintext = crypto::decrypt(&blob, &enc_key, aad).ok()?;
+    let raw = String::from_utf8(plaintext).ok()?;
+    let mut env = parse_envelope(&raw)?;
+    if env["from"].as_str() != Some(wire.from.as_str()) {
+        eprintln!(
+            "  [warn] dropped message in room '{}' due to sender/signature mismatch",
+            room_id
+        );
+        return None;
+    }
+    env["_auth"] = json!("verified");
+    Some(env)
 }
 
 fn decrypt_payload(payload: &str, room_key: &[u8; 32], room_id: &str) -> Option<serde_json::Value> {
+    if payload.trim_start().starts_with('{') {
+        return decrypt_signed_payload(payload, room_key, room_id);
+    }
+
     let (enc_key, _) = crypto::derive_message_keys(room_key);
     let blob = BASE64.decode(payload).ok()?;
     let aad = room_id.as_bytes();
     let plaintext = crypto::decrypt(&blob, &enc_key, aad).ok()?;
     let raw = String::from_utf8(plaintext).ok()?;
-    parse_envelope(&raw)
+    let mut env = parse_envelope(&raw)?;
+    env["_auth"] = json!("unsigned");
+    Some(env)
 }
 
 // ── Room Operations ─────────────────────────────────────────────
@@ -1483,7 +1553,13 @@ pub fn download_file(file_id: &str, out_path: Option<&str>, room_label: Option<&
 
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
     use super::{pin, pins, resolve_room, send_watch_heartbeat, unpin};
+    use super::{
+        decrypt_payload, encrypt_envelope, make_envelope, signing_message_bytes, SignedWirePayload,
+        SIGNED_WIRE_VERSION, BASE64,
+    };
+    use crate::crypto;
     use crate::store::{self, Role};
     use serde_json::json;
     use std::path::PathBuf;
@@ -1612,6 +1688,92 @@ mod tests {
         assert_eq!(unpinned, first);
         assert!(removed);
         assert!(pins(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn signed_payload_round_trip_marks_verified() {
+        let _guard = env_lock().lock().unwrap();
+        let home = temp_home();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "sign-test");
+        }
+
+        let room = store::add_room("ag-sign", "secret-sign", "sign", Role::Admin);
+        let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
+        let env = make_envelope("hello signed world", None);
+        let wire = encrypt_envelope(&env, &room_key, &room.room_id);
+        let decrypted = decrypt_payload(&wire, &room_key, &room.room_id).unwrap();
+
+        assert_eq!(decrypted["text"].as_str(), Some("hello signed world"));
+        assert_eq!(decrypted["_auth"].as_str(), Some("verified"));
+        assert!(store::get_trusted_signing_key("sign-test").is_some());
+    }
+
+    #[test]
+    fn legacy_payload_round_trip_marks_unsigned() {
+        let _guard = env_lock().lock().unwrap();
+        let room_key = crypto::derive_room_key("secret-legacy", "ag-legacy");
+        let env = json!({
+            "v": "3.0",
+            "id": "legacy01",
+            "from": "legacy-agent",
+            "ts": 123,
+            "text": "legacy message",
+        });
+        let plaintext = serde_json::to_string(&env).unwrap();
+        let (enc_key, _) = crypto::derive_message_keys(&room_key);
+        let blob = crypto::encrypt(plaintext.as_bytes(), &enc_key, b"ag-legacy").unwrap();
+        let raw = BASE64.encode(&blob);
+
+        let decrypted = decrypt_payload(&raw, &room_key, "ag-legacy").unwrap();
+        assert_eq!(decrypted["text"].as_str(), Some("legacy message"));
+        assert_eq!(decrypted["_auth"].as_str(), Some("unsigned"));
+    }
+
+    #[test]
+    fn signed_payload_rejects_trusted_key_mismatch() {
+        let _guard = env_lock().lock().unwrap();
+        let home = temp_home();
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "alice");
+        }
+
+        let room = store::add_room("ag-sign-mismatch", "secret-sign-mismatch", "sign-mismatch", Role::Admin);
+        let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
+
+        let trusted_env = make_envelope("trusted", None);
+        let trusted_wire = encrypt_envelope(&trusted_env, &room_key, &room.room_id);
+        assert!(decrypt_payload(&trusted_wire, &room_key, &room.room_id).is_some());
+
+        let forged_env = json!({
+            "v": "3.0",
+            "id": "forged01",
+            "from": "alice",
+            "ts": 456,
+            "text": "forged",
+        });
+        let plaintext = serde_json::to_string(&forged_env).unwrap();
+        let (enc_key, _) = crypto::derive_message_keys(&room_key);
+        let blob = crypto::encrypt(plaintext.as_bytes(), &enc_key, room.room_id.as_bytes()).unwrap();
+        let payload = BASE64.encode(&blob);
+
+        let alt_pkcs8 = crypto::generate_signing_keypair_pkcs8().unwrap();
+        let alt_pubkey = BASE64.encode(crypto::signing_public_key(&alt_pkcs8).unwrap());
+        let signing_input = signing_message_bytes(&room.room_id, "alice", &alt_pubkey, &payload);
+        let sig = BASE64.encode(crypto::sign_message(&alt_pkcs8, &signing_input).unwrap());
+        let forged_wire = serde_json::to_string(&SignedWirePayload {
+            v: SIGNED_WIRE_VERSION.to_string(),
+            from: "alice".to_string(),
+            payload,
+            signing_pubkey: alt_pubkey,
+            sig,
+        }).unwrap();
+
+        assert!(decrypt_payload(&forged_wire, &room_key, &room.room_id).is_none());
     }
 }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -11,6 +11,7 @@ use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey, NONCE_LEN};
 use ring::hkdf::{self, Salt, HKDF_SHA256};
 use ring::hmac;
 use ring::rand::{SecureRandom, SystemRandom};
+use ring::signature::{ED25519, Ed25519KeyPair, KeyPair, UnparsedPublicKey};
 
 /// Errors from crypto operations.
 #[derive(Debug)]
@@ -19,6 +20,7 @@ pub enum CryptoError {
     DecryptionFailed,
     InvalidKey,
     RngFailed,
+    SignatureFailed,
 }
 
 impl std::fmt::Display for CryptoError {
@@ -28,6 +30,7 @@ impl std::fmt::Display for CryptoError {
             Self::DecryptionFailed => write!(f, "decryption failed (wrong key or tampered)"),
             Self::InvalidKey => write!(f, "invalid key material"),
             Self::RngFailed => write!(f, "random number generation failed"),
+            Self::SignatureFailed => write!(f, "signature operation failed"),
         }
     }
 }
@@ -198,6 +201,29 @@ pub fn zkp_verify(
     data.extend_from_slice(nonce);
     data.extend_from_slice(challenge);
     hmac::verify(&hmac_key, &data, response).is_ok()
+}
+
+// ── Message Signing ─────────────────────────────────────────────
+
+pub fn generate_signing_keypair_pkcs8() -> Result<Vec<u8>, CryptoError> {
+    let rng = SystemRandom::new();
+    let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).map_err(|_| CryptoError::SignatureFailed)?;
+    Ok(pkcs8.as_ref().to_vec())
+}
+
+pub fn signing_public_key(pkcs8: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let pair = Ed25519KeyPair::from_pkcs8(pkcs8).map_err(|_| CryptoError::InvalidKey)?;
+    Ok(pair.public_key().as_ref().to_vec())
+}
+
+pub fn sign_message(pkcs8: &[u8], message: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let pair = Ed25519KeyPair::from_pkcs8(pkcs8).map_err(|_| CryptoError::InvalidKey)?;
+    Ok(pair.sign(message).as_ref().to_vec())
+}
+
+pub fn verify_message_signature(public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
+    let verifier = UnparsedPublicKey::new(&ED25519, public_key);
+    verifier.verify(message, signature).is_ok()
 }
 
 // ── Utilities ───────────────────────────────────────────────────
@@ -392,6 +418,25 @@ mod tests {
         let challenge = zkp_create_challenge().unwrap();
         let response = zkp_respond(&k1, &nonce, &challenge);
         assert!(!zkp_verify(&k2, &nonce, &challenge, &response));
+    }
+
+    #[test]
+    fn test_sign_and_verify_roundtrip() {
+        let pkcs8 = generate_signing_keypair_pkcs8().unwrap();
+        let public_key = signing_public_key(&pkcs8).unwrap();
+        let msg = b"agora signed payload";
+        let sig = sign_message(&pkcs8, msg).unwrap();
+        assert!(verify_message_signature(&public_key, msg, &sig));
+    }
+
+    #[test]
+    fn test_wrong_signing_key_fails_verification() {
+        let pkcs8_a = generate_signing_keypair_pkcs8().unwrap();
+        let pkcs8_b = generate_signing_keypair_pkcs8().unwrap();
+        let public_key_b = signing_public_key(&pkcs8_b).unwrap();
+        let msg = b"agora signed payload";
+        let sig_a = sign_message(&pkcs8_a, msg).unwrap();
+        assert!(!verify_message_signature(&public_key_b, msg, &sig_a));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -596,12 +596,16 @@ fn print_msg_with_depth(env: &serde_json::Value, depth: usize) {
     } else {
         String::new()
     };
+    let auth = match env["_auth"].as_str() {
+        Some("unsigned") => " [unsigned]",
+        _ => "",
+    };
     let indent = "    ".repeat(depth);
     let me = store::get_agent_id();
     if sender_id == me {
-        println!("  {indent}\x1b[92m[{time}] [{mid}] {sender}: {text}{reply}\x1b[0m");
+        println!("  {indent}\x1b[92m[{time}] [{mid}] {sender}: {text}{reply}{auth}\x1b[0m");
     } else {
-        println!("  {indent}\x1b[96m[{time}]\x1b[0m [{mid}]{reply} {sender}: {text}");
+        println!("  {indent}\x1b[96m[{time}]\x1b[0m [{mid}]{reply} {sender}: {text}{auth}");
     }
 }
 
@@ -1975,7 +1979,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{dm_room_label, parse_invite_token, targeted_invite_token, InviteTokenPayload};
-    use crate::store::RoomEntry;
+    use crate::store::{self, RoomEntry};
 
     #[test]
     fn dm_room_label_is_stable_and_symmetric() {
@@ -2011,6 +2015,9 @@ mod tests {
                 label: "dm-a-b".to_string(),
                 target_agent_id: Some("agent-b".to_string()),
                 purpose: Some("dm".to_string()),
+                expires_at: None,
+                max_uses: None,
+                created_by: Some(store::get_agent_id()),
             }
         );
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -121,6 +121,10 @@ pub fn render_message_html(m: &serde_json::Value, me: &str, room_id: &str) -> St
     } else {
         String::new()
     };
+    let auth_badge = match m["_auth"].as_str() {
+        Some("unsigned") => r#"<span class="auth auth-unsigned">unsigned</span> "#.to_string(),
+        _ => String::new(),
+    };
 
     let reactions = reaction_badges(room_id, mid);
     let receipt = receipt_mark(room_id, mid, me, m["from"].as_str().unwrap_or(""));
@@ -147,7 +151,8 @@ pub fn render_message_html(m: &serde_json::Value, me: &str, room_id: &str) -> St
     );
 
     format!(
-        r#"<div class="{class}" id="m-{mid_short}" data-text="{text_lower}"><span class="time">{dt}</span> <span class="id">[{mid_short}]</span> <span class="sender">{from}</span>: {reply_badge}<span class="text">{text}</span>{receipt}{reactions_row}{actions}</div>"#,
+        r#"<div class="{class}" id="m-{mid_short}" data-text="{text_lower}"><span class="time">{dt}</span> <span class="id">[{mid_short}]</span> <span class="sender">{from}</span> {auth_badge}: {reply_badge}<span class="text">{text}</span>{receipt}{reactions_row}{actions}</div>"#,
+        auth_badge = auth_badge,
         text_lower = html_escape(&m["text"].as_str().unwrap_or("").to_lowercase()),
     )
 }
@@ -172,6 +177,8 @@ h1{color:#58a6ff;font-size:1.2em;border-bottom:1px solid #30363d;padding-bottom:
 .sender{color:#58a6ff;font-weight:bold}
 .reply-to{color:#8b949e;font-size:.82em;background:#161b22;padding:1px 4px;border-radius:3px;margin-right:4px;cursor:pointer}
 .reply-to:hover{background:#21262d}
+.auth{font-size:.75em;padding:1px 5px;border-radius:999px;background:#161b22;border:1px solid #30363d;vertical-align:middle}
+.auth-unsigned{color:#d29922}
 .receipt{font-size:.8em;margin-left:4px}
 .receipt.seen2{color:#3fb950}
 .receipt.seen1{color:#8b949e}

--- a/src/store.rs
+++ b/src/store.rs
@@ -6,8 +6,9 @@
 //!   rooms.json                — room registry
 //!   identity.json             — agent identity
 
+use crate::crypto;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -67,6 +68,51 @@ pub fn get_agent_id() -> String {
     let json = serde_json::json!({"agent_id": agent_id});
     let _ = fs::write(&id_file, serde_json::to_string_pretty(&json).unwrap());
     agent_id
+}
+
+fn signing_keys_dir() -> PathBuf {
+    agora_dir().join("signing-keys")
+}
+
+pub fn load_or_create_signing_keypair(agent_id: &str) -> Result<Vec<u8>, String> {
+    let dir = signing_keys_dir();
+    ensure_dir(&dir);
+    let path = dir.join(format!("{agent_id}.pkcs8"));
+    if let Ok(data) = fs::read(&path) {
+        return Ok(data);
+    }
+
+    let pkcs8 = crypto::generate_signing_keypair_pkcs8().map_err(|e| e.to_string())?;
+    fs::write(&path, &pkcs8).map_err(|e| format!("failed to persist signing key: {e}"))?;
+    Ok(pkcs8)
+}
+
+// ── Trusted Signing Keys (TOFU) ────────────────────────────────
+
+pub fn load_trusted_signing_keys() -> HashMap<String, String> {
+    let path = agora_dir().join("trusted_signing_keys.json");
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        HashMap::new()
+    }
+}
+
+pub fn save_trusted_signing_keys(keys: &HashMap<String, String>) {
+    let dir = agora_dir();
+    ensure_dir(&dir);
+    let data = serde_json::to_string_pretty(keys).unwrap();
+    let _ = fs::write(dir.join("trusted_signing_keys.json"), data);
+}
+
+pub fn get_trusted_signing_key(agent_id: &str) -> Option<String> {
+    load_trusted_signing_keys().get(agent_id).cloned()
+}
+
+pub fn trust_signing_key(agent_id: &str, signing_pubkey: &str) {
+    let mut keys = load_trusted_signing_keys();
+    keys.insert(agent_id.to_string(), signing_pubkey.to_string());
+    save_trusted_signing_keys(&keys);
 }
 
 // ── Room Registry ───────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- sign the encrypted transport wrapper with a per-agent Ed25519 key stored in local Agora state
- verify signatures on receive and bind `agent_id -> signing pubkey` with trust-on-first-use
- drop signed messages that fail signature checks, sender binding, or trusted-key consistency
- keep legacy payloads readable but mark them as `unsigned` in the CLI and web UI
- add signing and TOFU coverage in the Rust test suite

## Why
DMs and room messages were still vulnerable to post-join sender spoofing because the bearer room secret alone authenticated membership, not the sender identity. This patch hardens sender authenticity after first contact without breaking existing rooms.

## Impact
- new rooms continue to interoperate with legacy clients because unsigned payloads still decrypt
- upgraded clients now distinguish verified traffic from legacy unsigned traffic
- spoofed signed traffic is rejected once a sender key has been learned locally

## Validation
- `cargo test`
- `cargo build --release`

## Limitations
- this is TOFU, not a global identity system
- first-contact authenticity is still not solved
- anyone with the room secret can still join unless invite/auth semantics are strengthened separately
