### PR TITLE
[codex] Enforce invite max-uses from room history

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ agora info                            Room info, members, fingerprint
 
 `agora dm` is an MVP convenience layer over a separate private room. It improves isolation from the main room and can generate target-bound invite tokens. When the peer signing key is already known from prior signed traffic, the DM invite is bound to that key instead of only `AGORA_AGENT_ID`. It is still not a cryptographic 1:1 identity guarantee yet because invites remain bearer secrets and first-contact identity is still TOFU-based.
 
+`agora invite --max-uses N` is now enforced from signed invite-redemption events in room history. That makes sequential overuse detectable without a central server, but concurrent accepts can still race, so the quota remains best-effort rather than a hard global guarantee.
+
 ### Presence & Profiles
 ```
 agora who [--online]                  List members, roles, online status

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -117,8 +117,30 @@ fn is_reaction(env: &serde_json::Value) -> bool {
     env["type"].as_str() == Some("reaction")
 }
 
+fn make_invite_redemption(
+    invite_id: &str,
+    invite_created_by: Option<&str>,
+    invite_max_uses: Option<u32>,
+) -> serde_json::Value {
+    json!({
+        "v": VERSION,
+        "id": msg_id(),
+        "from": store::get_agent_id(),
+        "ts": now(),
+        "type": "invite_redeem",
+        "invite_id": invite_id,
+        "invite_created_by": invite_created_by,
+        "invite_max_uses": invite_max_uses,
+        "text": "",
+    })
+}
+
+fn is_invite_redeem(env: &serde_json::Value) -> bool {
+    env["type"].as_str() == Some("invite_redeem")
+}
+
 fn is_system_msg(env: &serde_json::Value) -> bool {
-    is_heartbeat(env) || is_receipt(env) || is_file_msg(env) || is_reaction(env)
+    is_heartbeat(env) || is_receipt(env) || is_file_msg(env) || is_reaction(env) || is_invite_redeem(env)
 }
 
 /// Update last_seen for the sender of a message.
@@ -339,6 +361,64 @@ pub fn send(message: &str, reply_to: Option<&str>, room_label: Option<&str>) -> 
     Ok(mid)
 }
 
+fn count_invite_redemptions_in_envs(events: &[serde_json::Value], invite_id: &str) -> u32 {
+    let mut seen = HashSet::new();
+    let mut count = 0;
+    for env in events {
+        if !is_invite_redeem(env) {
+            continue;
+        }
+        if env["invite_id"].as_str() != Some(invite_id) {
+            continue;
+        }
+        let mid = env["id"].as_str().unwrap_or("");
+        if !mid.is_empty() && !seen.insert(mid.to_string()) {
+            continue;
+        }
+        count += 1;
+    }
+    count
+}
+
+pub fn count_invite_redemptions(
+    room_id: &str,
+    secret: &str,
+    invite_id: &str,
+    issued_at: Option<u64>,
+) -> Result<u32, String> {
+    let room_key = crypto::derive_room_key(secret, room_id);
+    let since = issued_at
+        .map(|ts| ts.to_string())
+        .unwrap_or_else(|| "24h".to_string());
+    let remote_events = transport::fetch(room_id, &since);
+    let mut events = Vec::new();
+    for (ts, payload) in &remote_events {
+        if let Some(mut env) = decrypt_payload(payload, &room_key, room_id) {
+            if env["ts"].as_u64().unwrap_or(0) == 0 {
+                env["ts"] = json!(ts);
+            }
+            events.push(env);
+        }
+    }
+    Ok(count_invite_redemptions_in_envs(&events, invite_id))
+}
+
+pub fn redeem_invite(
+    room_id: &str,
+    secret: &str,
+    invite_id: &str,
+    invite_created_by: Option<&str>,
+    invite_max_uses: Option<u32>,
+) -> Result<(), String> {
+    let room_key = crypto::derive_room_key(secret, room_id);
+    let env = make_invite_redemption(invite_id, invite_created_by, invite_max_uses);
+    let encrypted = encrypt_envelope(&env, &room_key, room_id);
+    if !transport::publish(room_id, &encrypted) {
+        return Err("failed to publish invite redemption to relay".to_string());
+    }
+    Ok(())
+}
+
 pub fn read(since: &str, limit: usize, room_label: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
@@ -369,8 +449,8 @@ pub fn read(since: &str, limit: usize, room_label: Option<&str>) -> Result<Vec<s
         seen_ids.insert(mid);
         // Track presence from all messages (including heartbeats)
         track_presence(&room.room_id, &msg);
-        // Only persist and display non-heartbeat messages
-        if !is_heartbeat(&msg) {
+        // Only persist and display non-heartbeat, non-invite-redemption messages.
+        if !is_heartbeat(&msg) && !is_invite_redeem(&msg) {
             store::save_message(&room.room_id, &msg);
             merged.push(msg);
         }
@@ -422,6 +502,10 @@ pub fn check(since: &str, room_label: Option<&str>) -> Result<Vec<serde_json::Va
             }
 
             if is_heartbeat(&env) {
+                continue;
+            }
+
+            if is_invite_redeem(&env) {
                 continue;
             }
 
@@ -1556,8 +1640,9 @@ mod tests {
     use base64::Engine;
     use super::{pin, pins, resolve_room, send_watch_heartbeat, unpin};
     use super::{
-        decrypt_payload, encrypt_envelope, make_envelope, signing_message_bytes, SignedWirePayload,
-        SIGNED_WIRE_VERSION, BASE64,
+        count_invite_redemptions_in_envs, decrypt_payload, encrypt_envelope, make_envelope,
+        make_invite_redemption, signing_message_bytes, SignedWirePayload, SIGNED_WIRE_VERSION,
+        BASE64,
     };
     use crate::crypto;
     use crate::store::{self, Role};
@@ -1768,6 +1853,18 @@ mod tests {
         }).unwrap();
 
         assert!(decrypt_payload(&forged_wire, &room_key, &room.room_id).is_none());
+    }
+
+    #[test]
+    fn invite_redemption_counter_matches_invite_id() {
+        let first = make_invite_redemption("invite-a", Some("alice"), Some(1));
+        let second = make_invite_redemption("invite-a", Some("alice"), Some(1));
+        let third = make_invite_redemption("invite-b", Some("alice"), Some(1));
+        let events = vec![first, second, third];
+
+        assert_eq!(count_invite_redemptions_in_envs(&events, "invite-a"), 2);
+        assert_eq!(count_invite_redemptions_in_envs(&events, "invite-b"), 1);
+        assert_eq!(count_invite_redemptions_in_envs(&events, "invite-c"), 0);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,10 @@ mod transport;
 
 use base64::Engine;
 use clap::{Parser, Subcommand};
+use ring::rand::SecureRandom;
 use serde::{Deserialize, Serialize};
 use std::process;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 const BASE64: base64::engine::general_purpose::GeneralPurpose =
     base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -23,6 +25,8 @@ struct InviteTokenPayload {
     room_id: String,
     secret: String,
     label: String,
+    #[serde(default)]
+    invite_id: Option<String>,
     #[serde(default)]
     target_agent_id: Option<String>,
     #[serde(default)]
@@ -35,6 +39,8 @@ struct InviteTokenPayload {
     max_uses: Option<u32>,
     #[serde(default)]
     created_by: Option<String>,
+    #[serde(default)]
+    issued_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -534,15 +540,24 @@ fn dm_room_label(left: &str, right: &str) -> Result<String, String> {
     Ok(format!("dm-{a}-{b}"))
 }
 
+fn invite_id() -> String {
+    let mut bytes = [0u8; 8];
+    ring::rand::SystemRandom::new()
+        .fill(&mut bytes)
+        .expect("RNG failed");
+    hex::encode(bytes)
+}
+
 fn invite_signing_message_bytes(
     payload: &InviteTokenPayload,
     inviter_signing_pubkey: &str,
 ) -> Vec<u8> {
     format!(
-        "agora-signed-invite-v1\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        "agora-signed-invite-v1\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
         payload.room_id,
         payload.secret,
         payload.label,
+        payload.invite_id.as_deref().unwrap_or(""),
         payload.target_agent_id.as_deref().unwrap_or(""),
         payload.target_signing_pubkey.as_deref().unwrap_or(""),
         payload.purpose.as_deref().unwrap_or(""),
@@ -552,6 +567,7 @@ fn invite_signing_message_bytes(
             .unwrap_or_default(),
         payload.max_uses.map(|v| v.to_string()).unwrap_or_default(),
         payload.created_by.as_deref().unwrap_or(""),
+        payload.issued_at.map(|v| v.to_string()).unwrap_or_default(),
         inviter_signing_pubkey,
     )
     .into_bytes()
@@ -564,6 +580,18 @@ fn local_signing_pubkey(agent_id: &str) -> Result<String, String> {
 }
 
 fn sign_invite_token(payload: InviteTokenPayload) -> Result<String, String> {
+    let mut payload = payload;
+    if payload.invite_id.is_none() {
+        payload.invite_id = Some(invite_id());
+    }
+    if payload.issued_at.is_none() {
+        payload.issued_at = Some(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        );
+    }
     let created_by = payload
         .created_by
         .clone()
@@ -596,12 +624,14 @@ fn targeted_invite_token(
         room_id: room.room_id.clone(),
         secret: room.secret.clone(),
         label: room.label.clone(),
+        invite_id: None,
         target_agent_id: Some(target_agent_id.to_string()),
         target_signing_pubkey: store::get_trusted_signing_key(target_agent_id),
         purpose: Some(purpose.to_string()),
         expires_at: None,
         max_uses: None,
         created_by: Some(store::get_agent_id()),
+        issued_at: None,
     };
     sign_invite_token(payload)
 }
@@ -656,23 +686,25 @@ fn parse_invite_token(token: &str) -> Result<ParsedInviteToken, String> {
     }
 
     Ok(ParsedInviteToken {
-        payload: InviteTokenPayload {
-            room_id: parts[0].to_string(),
-            secret: parts[1].to_string(),
-            label: if parts.len() == 3 {
-                parts[2].to_string()
-            } else {
-                parts[0][..12.min(parts[0].len())].to_string()
+            payload: InviteTokenPayload {
+                room_id: parts[0].to_string(),
+                secret: parts[1].to_string(),
+                label: if parts.len() == 3 {
+                    parts[2].to_string()
+                } else {
+                    parts[0][..12.min(parts[0].len())].to_string()
+                },
+                invite_id: None,
+                target_agent_id: None,
+                target_signing_pubkey: None,
+                purpose: None,
+                expires_at: None,
+                max_uses: None,
+                created_by: None,
+                issued_at: None,
             },
-            target_agent_id: None,
-            target_signing_pubkey: None,
-            purpose: None,
-            expires_at: None,
-            max_uses: None,
-            created_by: None,
-        },
-        auth: InviteTokenAuth::Unsigned,
-    })
+            auth: InviteTokenAuth::Unsigned,
+        })
 }
 
 fn print_msg(env: &serde_json::Value) {
@@ -780,12 +812,14 @@ fn main() {
                         room_id: r.room_id.clone(),
                         secret: r.secret.clone(),
                         label: r.label.clone(),
+                        invite_id: None,
                         target_agent_id: None,
                         target_signing_pubkey: None,
                         purpose: None,
                         expires_at,
                         max_uses,
                         created_by: Some(store::get_agent_id()),
+                        issued_at: None,
                     };
                     let token = match sign_invite_token(payload) {
                         Ok(token) => token,
@@ -856,8 +890,46 @@ fn main() {
                         }
                     }
 
+                    let redemption_count = if let (Some(max_uses), Some(invite_id)) =
+                        (payload.max_uses, payload.invite_id.as_deref())
+                    {
+                        match chat::count_invite_redemptions(
+                            &payload.room_id,
+                            &payload.secret,
+                            invite_id,
+                            payload.issued_at,
+                        ) {
+                            Ok(used) => {
+                                if used >= max_uses {
+                                    eprintln!(
+                                        "  Error: invite token has reached its max uses ({used}/{max_uses})."
+                                    );
+                                    process::exit(1);
+                                }
+                                Some(used)
+                            }
+                            Err(e) => {
+                                eprintln!("  Error: failed to verify invite usage: {e}");
+                                process::exit(1);
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
                     match chat::join(&payload.room_id, &payload.secret, &payload.label) {
                         Ok(_) => {
+                            if let Some(invite_id) = payload.invite_id.as_deref() {
+                                if let Err(e) = chat::redeem_invite(
+                                    &payload.room_id,
+                                    &payload.secret,
+                                    invite_id,
+                                    payload.created_by.as_deref(),
+                                    payload.max_uses,
+                                ) {
+                                    eprintln!("  Warning: failed to record invite redemption: {e}");
+                                }
+                            }
                             let room_key = crypto::derive_room_key(&payload.secret, &payload.room_id);
                             println!("  Joined room '{}'", payload.label);
                             println!("  Encryption: AES-256-GCM + HKDF-SHA256");
@@ -869,6 +941,13 @@ fn main() {
                                 InviteTokenAuth::Unsigned => {
                                     println!("  Invite signature: unsigned legacy token");
                                 }
+                            }
+                            if let (Some(used_before), Some(max_uses)) = (redemption_count, payload.max_uses) {
+                                println!(
+                                    "  Invite uses: {}/{} (best-effort decentralized check)",
+                                    used_before + 1,
+                                    max_uses
+                                );
                             }
                             if payload.purpose.as_deref() == Some("dm") {
                                 if payload.target_signing_pubkey.is_some() {
@@ -2224,15 +2303,19 @@ mod tests {
                 room_id: "ag-dm-test".to_string(),
                 secret: "secret".to_string(),
                 label: "dm-a-b".to_string(),
+                invite_id: parsed.payload.invite_id.clone(),
                 target_agent_id: Some("agent-b".to_string()),
                 target_signing_pubkey: Some("cGVlci1zaWduaW5nLWtleQ".to_string()),
                 purpose: Some("dm".to_string()),
                 expires_at: None,
                 max_uses: None,
                 created_by: Some(store::get_agent_id()),
+                issued_at: parsed.payload.issued_at,
             }
         );
         assert_eq!(parsed.auth, InviteTokenAuth::SignedVerified);
+        assert!(parsed.payload.invite_id.is_some());
+        assert!(parsed.payload.issued_at.is_some());
     }
 
     #[test]
@@ -2272,8 +2355,10 @@ mod tests {
         assert_eq!(parsed.payload.room_id, "ag-room");
         assert_eq!(parsed.payload.secret, "secret");
         assert_eq!(parsed.payload.label, "label");
+        assert_eq!(parsed.payload.invite_id, None);
         assert_eq!(parsed.payload.target_agent_id, None);
         assert_eq!(parsed.payload.target_signing_pubkey, None);
+        assert_eq!(parsed.payload.issued_at, None);
         assert_eq!(parsed.auth, InviteTokenAuth::Unsigned);
     }
 }


### PR DESCRIPTION
## What changed
- add signed invite `invite_id` and `issued_at` fields
- enforce `agora invite --max-uses` by counting prior `invite_redeem` events from encrypted room history during `accept`
- publish an `invite_redeem` system event after successful accept so later accepts can see prior usage
- keep legacy invite tokens compatible
- document the remaining race: concurrent accepts can still oversubscribe because there is no central coordinator

## Why
After #34, invite integrity was signed, but `--max-uses` was still dead metadata. The token carried the number and the CLI printed it, yet `accept` ignored it completely.

## Security / consistency boundary
- sequential overuse is now detected from room history without a central service
- the quota is still best-effort under concurrent races
- bearer-secret membership and first-contact TOFU limits are unchanged

## Validation
- `cargo test`
- `cargo build --release`
