### PR TITLE
[codex] Fix autonomous task claim parsing

### DIFF
--- a/agent.sh
+++ b/agent.sh
@@ -17,6 +17,17 @@ export AGORA_AGENT_ID="$AGENT_ID"
 
 log() { echo "[$(date '+%H:%M:%S')] $*"; }
 
+first_open_task_id() {
+    $AGORA --room collab tasks 2>/dev/null | awk '
+        /^  Open \([0-9]+\):/ { in_open=1; next }
+        /^  [A-Za-z].*\([0-9]+\):/ { if (in_open) exit }
+        in_open && match($0, /\[[[:alnum:]]+\]/) {
+            print substr($0, RSTART + 1, RLENGTH - 2)
+            exit
+        }
+    '
+}
+
 required_check_buckets() {
     local pr_num="$1"
     local output=""
@@ -92,15 +103,13 @@ while true; do
         $AGORA --room "$room" heartbeat 2>/dev/null || true
     done
 
-    # 2. Check for open tasks and claim one if idle
-    OPEN_TASKS=$($AGORA --room collab tasks 2>/dev/null | grep -c "^\s*\[" || echo "0")
-    if [ "$OPEN_TASKS" -gt 0 ]; then
-        # Get first open task ID
-        TASK_ID=$($AGORA --room collab tasks 2>/dev/null | grep "Open" -A1 | grep "^\s*\[" | head -1 | sed 's/.*\[\(.*\)\].*/\1/' | tr -d ' ' || true)
-        if [ -n "$TASK_ID" ]; then
-            log "Claiming task: $TASK_ID"
-            $AGORA --room collab task-claim "$TASK_ID" 2>/dev/null || true
-        fi
+    # 2. Check for open tasks and claim one if available
+    TASK_ID=$(first_open_task_id || true)
+    if [ -n "$TASK_ID" ]; then
+        log "Claiming task: $TASK_ID"
+        $AGORA --room collab task-claim "$TASK_ID" 2>/dev/null || true
+    else
+        log "No open tasks to claim"
     fi
 
     # 3. Check for open PRs and merge if CI passes


### PR DESCRIPTION
## What changed
- replace the task-claim scrape in `agent.sh` with a parser that reads only the `Open (...)` section
- stop treating any bracketed task line from `In Progress` / `Done` as evidence that a claimable task exists
- log `No open tasks to claim` when the room has no open tasks

## Why
The previous logic counted all bracketed task lines and then scraped formatted output with `grep "Open" -A1`. In rooms with only `In Progress` and `Done` tasks, the autonomous loop still thought there were tasks to inspect even though no open task existed.

## Validation
- `bash -n agent.sh`
- sourced `first_open_task_id` against the real current `collab` output with no `Open` section -> empty result
- synthetic `Open` section sample -> extracted `abc123`
