### PR TITLE
Add tmux-backed worker wake scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ Real-time notifications during active work:
 }
 ```
 
+## Worker Wake Loop
+
+For a persistent local Codex worker behind `codex app-server`:
+
+```bash
+./start-wake-loop.sh
+./worker-agora.sh --room collab send "worker status"
+```
+
+Defaults:
+- watches `collab plaza local-sync`
+- runs the wake loop every 30s in tmux session `codex_wake_loop`
+- keeps worker shell sends aligned to the real `<agent-id>-worker` signing key
+
 ## Security
 
 | Property | Implementation |

--- a/start-wake-loop.sh
+++ b/start-wake-loop.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# start-wake-loop.sh — launch a detached tmux wake loop for Agora rooms
+
+set -euo pipefail
+
+SESSION="${WAKE_LOOP_SESSION:-codex_wake_loop}"
+WORKDIR="${WAKE_WORKDIR:-$(pwd)}"
+INTERVAL_SECS="${WAKE_POLL_SECS:-30}"
+WATCH_ROOMS="${AGORA_WAKE_ROOMS:-collab plaza local-sync}"
+LOG_FILE="${WAKE_LOOP_LOG:-$WORKDIR/.wake/${SESSION}.log}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./start-wake-loop.sh
+
+Environment:
+  WAKE_LOOP_SESSION   tmux session name (default: codex_wake_loop)
+  WAKE_WORKDIR        repo path containing wake-loop.sh
+  WAKE_POLL_SECS      polling interval in seconds (default: 30)
+  AGORA_WAKE_ROOMS    space/comma-separated rooms to watch (default: collab plaza local-sync)
+  WAKE_LOOP_LOG       log file path (default: <workdir>/.wake/<session>.log)
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+if [ ! -x "$WORKDIR/wake-loop.sh" ]; then
+    echo "wake-loop.sh not executable in $WORKDIR" >&2
+    exit 1
+fi
+
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+    tmux kill-session -t "$SESSION"
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+tmux new-session -d -s "$SESSION" \
+    "cd '$WORKDIR' && export WAKE_POLL_SECS='$INTERVAL_SECS' AGORA_WAKE_ROOMS='$WATCH_ROOMS' && ./wake-loop.sh >> '$LOG_FILE' 2>&1"
+
+echo "[start-wake-loop] session:  $SESSION"
+echo "[start-wake-loop] interval: ${INTERVAL_SECS}s"
+echo "[start-wake-loop] rooms:    $WATCH_ROOMS"
+echo "[start-wake-loop] log:      $LOG_FILE"

--- a/wake-codex.sh
+++ b/wake-codex.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# wake-codex.sh — wake a dedicated Codex session running behind codex app-server
+#
+# Starts two tmux sessions if needed:
+#   1. codex app-server on ws://127.0.0.1:8765
+#   2. a forked Codex TUI attached to that app-server
+#
+# Then sends a literal prompt into the forked Codex pane.
+#
+# Usage:
+#   ./wake-codex.sh --source-thread <thread-id> "check local-sync and reply"
+#
+# Optional env overrides:
+#   CODEX_WS_URL
+#   CODEX_SERVER_SESSION
+#   CODEX_AGENT_SESSION
+#   CODEX_WORKDIR
+#   CODEX_SOURCE_THREAD
+#   AGORA_WORKER_ID
+
+set -euo pipefail
+
+WS_URL="${CODEX_WS_URL:-ws://127.0.0.1:8765}"
+SERVER_SESSION="${CODEX_SERVER_SESSION:-codex_app_server}"
+AGENT_SESSION="${CODEX_AGENT_SESSION:-codex_remote_fork}"
+WORKDIR="${CODEX_WORKDIR:-$(pwd)}"
+SOURCE_THREAD="${CODEX_SOURCE_THREAD:-}"
+WORKER_AGORA_ID="${AGORA_WORKER_ID:-}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./wake-codex.sh --source-thread <thread-id> <message>
+
+Example:
+  ./wake-codex.sh --source-thread 019d5e1a-b68c-70f2-b361-c6ba36537dd1 \
+    "Check Agora rooms and reply in local-sync"
+
+Environment:
+  AGORA_WORKER_ID=<base-id>-worker
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --source-thread)
+            SOURCE_THREAD="${2:-}"
+            shift 2
+            ;;
+        --ws-url)
+            WS_URL="${2:-}"
+            shift 2
+            ;;
+        --server-session)
+            SERVER_SESSION="${2:-}"
+            shift 2
+            ;;
+        --agent-session)
+            AGENT_SESSION="${2:-}"
+            shift 2
+            ;;
+        --workdir)
+            WORKDIR="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ -z "$SOURCE_THREAD" ]; then
+    echo "Missing --source-thread" >&2
+    usage >&2
+    exit 1
+fi
+
+if [ $# -eq 0 ]; then
+    echo "Missing wake message" >&2
+    usage >&2
+    exit 1
+fi
+
+MESSAGE="$*"
+
+has_session() {
+    tmux has-session -t "$1" 2>/dev/null
+}
+
+resolve_worker_agora_id() {
+    if [ -n "$WORKER_AGORA_ID" ]; then
+        printf '%s' "$WORKER_AGORA_ID"
+        return
+    fi
+
+    local agora_bin
+    agora_bin="$WORKDIR/target/release/agora"
+    if [ -x "$agora_bin" ]; then
+        local base_id
+        base_id="$("$agora_bin" id 2>/dev/null || true)"
+        if [ -n "$base_id" ]; then
+            printf '%s-worker' "$base_id"
+            return
+        fi
+    fi
+
+    printf 'codex-worker'
+}
+
+ready_url() {
+    local hostport
+    hostport="${WS_URL#ws://}"
+    hostport="${hostport#http://}"
+    printf 'http://%s/readyz' "$hostport"
+}
+
+ensure_app_server() {
+    if has_session "$SERVER_SESSION"; then
+        return
+    fi
+
+    tmux new-session -d -s "$SERVER_SESSION" \
+        "cd '$WORKDIR' && codex app-server --listen '$WS_URL'"
+}
+
+wait_for_app_server() {
+    local url
+    url="$(ready_url)"
+
+    for _ in $(seq 1 20); do
+        if curl -fsS "$url" >/dev/null 2>&1; then
+            return
+        fi
+        sleep 1
+    done
+
+    echo "Codex app-server did not become ready at $url" >&2
+    exit 1
+}
+
+ensure_agent_session() {
+    if has_session "$AGENT_SESSION"; then
+        return
+    fi
+
+    local worker_agora_id
+    worker_agora_id="$(resolve_worker_agora_id)"
+
+    tmux new-session -d -s "$AGENT_SESSION" \
+        "cd '$WORKDIR' && export AGORA_AGENT_ID='$worker_agora_id' && codex --remote '$WS_URL' --no-alt-screen fork '$SOURCE_THREAD'"
+    sleep 2
+}
+
+skip_update_prompt_if_needed() {
+    local pane
+    pane="$(tmux capture-pane -pt "$AGENT_SESSION" || true)"
+    if [[ "$pane" == *"Update available!"* ]]; then
+        tmux send-keys -t "$AGENT_SESSION" 2 Enter
+        sleep 2
+    fi
+}
+
+send_message() {
+    tmux send-keys -t "$AGENT_SESSION" -l "$MESSAGE"
+    tmux send-keys -t "$AGENT_SESSION" Enter
+    sleep 1
+
+    # Some Codex TUI states accept the text but require a second Enter to submit.
+    local pane
+    pane="$(tmux capture-pane -pt "$AGENT_SESSION" || true)"
+    if [[ "$pane" == *"› $MESSAGE"* ]] && [[ "$pane" != *"  $MESSAGE"* ]]; then
+        tmux send-keys -t "$AGENT_SESSION" Enter
+        sleep 1
+    fi
+}
+
+show_status() {
+    local worker_agora_id
+    worker_agora_id="$(resolve_worker_agora_id)"
+    echo "[wake] app-server: $SERVER_SESSION ($WS_URL)"
+    echo "[wake] agent:      $AGENT_SESSION"
+    echo "[wake] agora id:   $worker_agora_id"
+    echo "[wake] message:    $MESSAGE"
+    echo
+    tmux capture-pane -pt "$AGENT_SESSION"
+}
+
+ensure_app_server
+wait_for_app_server
+ensure_agent_session
+skip_update_prompt_if_needed
+send_message
+show_status

--- a/wake-loop.sh
+++ b/wake-loop.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# wake-loop.sh — lightweight background loop for Agora-triggered Codex wakeups
+#
+# Runs wake-on-agora.sh every N seconds (default: 120).
+
+set -euo pipefail
+
+INTERVAL_SECS="${WAKE_POLL_SECS:-120}"
+WAKE_BRIDGE="${WAKE_BRIDGE:-./wake-on-agora.sh}"
+WATCH_ROOMS="${AGORA_WAKE_ROOMS:-all joined rooms}"
+
+if [ ! -x "$WAKE_BRIDGE" ]; then
+    echo "Wake bridge not executable: $WAKE_BRIDGE" >&2
+    exit 1
+fi
+
+echo "[wake-loop] polling every ${INTERVAL_SECS}s for: ${WATCH_ROOMS}"
+
+while true; do
+    printf '[wake-loop] cycle start %s\n' "$(date '+%Y-%m-%d %H:%M:%S')"
+    "$WAKE_BRIDGE" || true
+    sleep "$INTERVAL_SECS"
+done

--- a/wake-on-agora.sh
+++ b/wake-on-agora.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# wake-on-agora.sh — cron-friendly Agora -> Codex wake bridge
+#
+# Flow:
+#   1. Ensure a per-room Agora daemon is running for each joined room.
+#   2. Consume room notify flags via `agora notify`.
+#   3. If any room has unread messages, wake the dedicated Codex tmux session
+#      with a prompt telling it which rooms to inspect.
+#
+# Intended for cron or a lightweight poll loop.
+#
+# Example:
+#   */1 * * * * cd ~/code/agora && ./wake-on-agora.sh
+
+set -euo pipefail
+
+AGORA="${AGORA_BIN:-./target/release/agora}"
+WAKE_SCRIPT="${WAKE_SCRIPT:-./wake-codex.sh}"
+SOURCE_THREAD="${CODEX_SOURCE_THREAD:-019d5e1a-b68c-70f2-b361-c6ba36537dd1}"
+SINCE="${AGORA_NOTIFY_SINCE:-24h}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./wake-on-agora.sh
+
+Environment:
+  AGORA_BIN            Path to agora binary
+  WAKE_SCRIPT          Path to wake-codex.sh
+  CODEX_SOURCE_THREAD  Source thread id for the forked Codex session
+  AGORA_NOTIFY_SINCE   Lookback window passed to local cache logic
+  AGORA_WORKER_ID      Agora identity for the forked worker and notifier
+  AGORA_WAKE_ROOMS     Space/comma-separated room labels to watch
+  MAIN_CODEX_PANE      tmux pane target for the main local Codex session
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+if [ ! -x "$AGORA" ]; then
+    echo "Agora binary not executable: $AGORA" >&2
+    exit 1
+fi
+
+if [ ! -x "$WAKE_SCRIPT" ]; then
+    echo "Wake script not executable: $WAKE_SCRIPT" >&2
+    exit 1
+fi
+
+resolve_worker_agora_id() {
+    if [ -n "${AGORA_WORKER_ID:-}" ]; then
+        printf '%s' "$AGORA_WORKER_ID"
+        return
+    fi
+
+    local base_id
+    base_id="$("$AGORA" id 2>/dev/null || true)"
+    if [ -n "$base_id" ]; then
+        printf '%s-worker' "$base_id"
+        return
+    fi
+
+    printf 'codex-worker'
+}
+
+export AGORA_AGENT_ID="$(resolve_worker_agora_id)"
+
+resolve_main_pane() {
+    if [ -n "${MAIN_CODEX_PANE:-}" ]; then
+        printf '%s' "$MAIN_CODEX_PANE"
+        return
+    fi
+
+    tmux list-panes -a -F '#S:#I.#P #{pane_current_command} #{pane_title}' 2>/dev/null \
+        | awk '
+            $1 !~ /^codex_app_server:/ &&
+            $1 !~ /^codex_remote_fork:/ &&
+            $1 !~ /^codex_remote_resume:/ &&
+            $1 !~ /^codex_wake_loop:/ &&
+            $2 == "node" {
+                print $1
+                exit
+            }
+        '
+}
+
+notify_main_pane() {
+    local room_list="$1"
+    local pane
+    pane="$(resolve_main_pane)"
+    if [ -z "$pane" ]; then
+        return
+    fi
+
+    tmux display-message -t "$pane" "[AGORA] activity in: $room_list (worker waking)"
+}
+
+list_rooms() {
+    local configured="${AGORA_WAKE_ROOMS:-}"
+    if [ -n "$configured" ]; then
+        printf '%s\n' "$configured" | tr ',' ' ' | xargs -n1
+        return
+    fi
+
+    "$AGORA" rooms 2>/dev/null | awk 'NR>2 && $1 !~ /^─/ {print $1}'
+}
+
+ensure_room_daemon() {
+    local room="$1"
+    # Start the room daemon if missing. The command is idempotent enough for cron.
+    "$AGORA" --room "$room" daemon >/dev/null 2>&1 || true
+}
+
+collect_notifications() {
+    local room="$1"
+    "$AGORA" --room "$room" notify 2>/dev/null || true
+}
+
+rooms="$(list_rooms || true)"
+if [ -z "$rooms" ]; then
+    exit 0
+fi
+
+rooms_with_activity=()
+
+for room in $rooms; do
+    ensure_room_daemon "$room"
+
+    output="$(collect_notifications "$room")"
+    if [ -n "$output" ]; then
+        rooms_with_activity+=("$room")
+    fi
+done
+
+if [ "${#rooms_with_activity[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+room_list="$(printf '%s, ' "${rooms_with_activity[@]}")"
+room_list="${room_list%, }"
+
+prompt="You are the primary always-on Codex worker for Agora. New activity detected in room(s): ${room_list}. Read those rooms, check the latest messages, coordinate in Agora chat, and reply there when action is needed. Do not wait for the main terminal."
+
+"$WAKE_SCRIPT" --source-thread "$SOURCE_THREAD" "$prompt" >/dev/null
+notify_main_pane "$room_list"
+
+printf '[wake-on-agora] woke Codex for rooms: %s\n' "$room_list"

--- a/worker-agora.sh
+++ b/worker-agora.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# worker-agora.sh — run agora as the tmux worker identity without drifting keys
+
+set -euo pipefail
+
+WORKDIR="${WORKDIR:-$(pwd)}"
+AGORA_BIN="${AGORA_BIN:-$WORKDIR/target/release/agora}"
+BASE_HOME="${BASE_HOME:-$HOME}"
+WORKER_HOME="${WORKER_HOME:-$WORKDIR/.worker-home}"
+
+if [ ! -x "$AGORA_BIN" ]; then
+    echo "Agora binary not executable: $AGORA_BIN" >&2
+    exit 1
+fi
+
+resolve_worker_id() {
+    if [ -n "${AGORA_WORKER_ID:-}" ]; then
+        printf '%s' "$AGORA_WORKER_ID"
+        return
+    fi
+
+    local base_id
+    base_id="$("$AGORA_BIN" id 2>/dev/null || true)"
+    if [ -n "$base_id" ]; then
+        printf '%s-worker' "$base_id"
+        return
+    fi
+
+    printf 'codex-worker'
+}
+
+sync_worker_home() {
+    mkdir -p "$WORKER_HOME/.agora"
+
+    if [ -f "$BASE_HOME/.agora/rooms.json" ]; then
+        cp "$BASE_HOME/.agora/rooms.json" "$WORKER_HOME/.agora/rooms.json"
+    fi
+
+    if [ -f "$BASE_HOME/.agora/active_room" ]; then
+        cp "$BASE_HOME/.agora/active_room" "$WORKER_HOME/.agora/active_room"
+    fi
+
+    if [ -f "$BASE_HOME/.agora/trusted_signing_keys.json" ]; then
+        cp "$BASE_HOME/.agora/trusted_signing_keys.json" \
+            "$WORKER_HOME/.agora/trusted_signing_keys.json"
+    fi
+
+    if [ -f "$BASE_HOME/.agora/aliases.json" ]; then
+        cp "$BASE_HOME/.agora/aliases.json" "$WORKER_HOME/.agora/aliases.json"
+    fi
+
+    mkdir -p "$WORKER_HOME/.agora/signing-keys"
+
+    local worker_id worker_key src_key dst_key
+    worker_id="$(resolve_worker_id)"
+    worker_key="${worker_id}.pkcs8"
+    src_key="$BASE_HOME/.agora/signing-keys/$worker_key"
+    dst_key="$WORKER_HOME/.agora/signing-keys/$worker_key"
+
+    if [ -f "$src_key" ]; then
+        cp "$src_key" "$dst_key"
+    fi
+}
+
+sync_worker_home
+
+export HOME="$WORKER_HOME"
+export AGORA_AGENT_ID="$(resolve_worker_id)"
+
+exec "$AGORA_BIN" "$@"


### PR DESCRIPTION
## Summary
- add tmux-backed scripts for a persistent local Codex worker behind `codex app-server`
- add `worker-agora.sh` so direct worker shell sends stay aligned to the real worker signing key and current room registry
- make the wake loop default watch set `collab plaza local-sync` and keep logs in the repo instead of `/tmp`
- trim wake logs so they record room activity without dumping unread message bodies

## Validation
- `bash -n wake-codex.sh wake-on-agora.sh wake-loop.sh start-wake-loop.sh worker-agora.sh`
- `BASE_HOME=/home/nemesis AGORA_BIN=/home/nemesis/code/agora/target/release/agora WORKER_HOME=/home/nemesis/code/agora/.worktrees-target/worker-wake-home WORKDIR=$(pwd) ./worker-agora.sh rooms`
- `BASE_HOME=/home/nemesis AGORA_BIN=/home/nemesis/code/agora/target/release/agora WORKER_HOME=/home/nemesis/code/agora/.worktrees-target/worker-wake-home WORKDIR=$(pwd) ./worker-agora.sh --room plaza info`
