### PR TITLE
Document and test relay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ agora serve --port 8080
 # Open http://localhost:8080 — dark theme, SSE live updates, send form
 ```
 
+## Relay Configuration
+
+Agora defaults to `https://ntfy.sh`, but the relay is configurable:
+
+```bash
+export AGORA_RELAY_URL=https://ntfy.theagora.dev
+```
+
+For zero-downtime relay migration, dual-publish during the cutover:
+
+```bash
+export AGORA_RELAY_URL=https://ntfy.theagora.dev
+export AGORA_RELAY_MIRROR=https://ntfy.sh
+```
+
 ## Hook Integration
 
 Real-time notifications during active work:
@@ -184,7 +199,7 @@ Real-time notifications during active work:
 | Membership Proof | Zero-knowledge (HMAC challenge-response) |
 | Anti-replay | Room ID bound as AAD |
 
-The relay (ntfy.sh) only sees ciphertext. No accounts, no auth tokens.
+The relay only sees ciphertext. No accounts, no auth tokens.
 
 ## Architecture
 
@@ -193,7 +208,7 @@ src/
   main.rs       CLI (clap, 30+ commands)
   crypto.rs     AES-256-GCM, HKDF, per-sender ratchet, ZKP
   chat.rs       Engine: send, read, search, thread, watch, files, reactions, receipts
-  transport.rs  ntfy.sh relay (reqwest + SSE, native TLS)
+  transport.rs  Configurable ntfy relay (reqwest + SSE, native TLS)
   store.rs      Persistence (~/.agora/), rooms, profiles, pins, receipts, reactions
   serve.rs      Web UI (HTTP server, SSE live updates, dark theme)
   mcp.rs        MCP stdio server (JSON-RPC 2.0)

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -132,3 +132,51 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{mirror_url, relay_url, DEFAULT_RELAY};
+    use crate::store;
+
+    fn restore_env(name: &str, value: Option<String>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var(name, value) },
+            None => unsafe { std::env::remove_var(name) },
+        }
+    }
+
+    #[test]
+    fn relay_url_defaults_to_ntfy() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let prior = std::env::var("AGORA_RELAY_URL").ok();
+        unsafe { std::env::remove_var("AGORA_RELAY_URL") };
+
+        assert_eq!(relay_url(), DEFAULT_RELAY);
+
+        restore_env("AGORA_RELAY_URL", prior);
+    }
+
+    #[test]
+    fn relay_url_uses_env_override() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let prior = std::env::var("AGORA_RELAY_URL").ok();
+        unsafe { std::env::set_var("AGORA_RELAY_URL", "https://ntfy.theagora.dev") };
+
+        assert_eq!(relay_url(), "https://ntfy.theagora.dev");
+
+        restore_env("AGORA_RELAY_URL", prior);
+    }
+
+    #[test]
+    fn mirror_url_is_optional() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let prior = std::env::var("AGORA_RELAY_MIRROR").ok();
+        unsafe { std::env::remove_var("AGORA_RELAY_MIRROR") };
+        assert_eq!(mirror_url(), None);
+
+        unsafe { std::env::set_var("AGORA_RELAY_MIRROR", "https://ntfy.sh") };
+        assert_eq!(mirror_url(), Some("https://ntfy.sh".to_string()));
+
+        restore_env("AGORA_RELAY_MIRROR", prior);
+    }
+}


### PR DESCRIPTION
## Summary
- document `AGORA_RELAY_URL` and `AGORA_RELAY_MIRROR` in the README
- update the relay wording so docs no longer assume `ntfy.sh` is the only deployment target
- add transport tests for the default relay, relay override, and optional mirror

## Validation
- `TMPDIR=/home/nemesis/code/agora/.tmp-tests CARGO_TARGET_DIR=/home/nemesis/code/agora/.worktrees-target/relay-docs-tests cargo test`
