### PR TITLE
Load wake script defaults from .agora-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ Defaults:
 - watches `collab plaza local-sync`
 - runs the wake loop every 30s in tmux session `codex_wake_loop`
 - keeps worker shell sends aligned to the real `<agent-id>-worker` signing key
+- reads optional helper defaults from `.agora-env` so the wake stack can share `AGORA_RELAY_URL`, `AGORA_RELAY_MIRROR`, and room/watch settings
+
+Example `.agora-env`:
+
+```bash
+AGORA_RELAY_URL=https://ntfy.theagora.dev
+AGORA_WAKE_ROOMS="collab plaza local-sync"
+WAKE_POLL_SECS=30
+```
 
 ## Security
 

--- a/agora-env.sh
+++ b/agora-env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# agora-env.sh — load simple KEY=value defaults for local Agora helper scripts
+
+resolve_agora_env_file() {
+    local workdir="${1:-$(pwd)}"
+    printf '%s' "${AGORA_ENV_FILE:-$workdir/.agora-env}"
+}
+
+load_agora_env_defaults() {
+    local workdir="${1:-$(pwd)}"
+    local env_file
+    env_file="$(resolve_agora_env_file "$workdir")"
+
+    if [ ! -f "$env_file" ]; then
+        return 0
+    fi
+
+    local line name value
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            ''|\#*)
+                continue
+                ;;
+        esac
+
+        if [[ "$line" != *=* ]]; then
+            continue
+        fi
+
+        name="${line%%=*}"
+        value="${line#*=}"
+
+        if [[ ! "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            continue
+        fi
+
+        if [ -n "${!name+x}" ]; then
+            continue
+        fi
+
+        if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+            value="${value:1:-1}"
+        elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+            value="${value:1:-1}"
+        fi
+
+        export "$name=$value"
+    done < "$env_file"
+}

--- a/start-wake-loop.sh
+++ b/start-wake-loop.sh
@@ -3,11 +3,16 @@
 
 set -euo pipefail
 
-SESSION="${WAKE_LOOP_SESSION:-codex_wake_loop}"
 WORKDIR="${WAKE_WORKDIR:-$(pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/agora-env.sh"
+load_agora_env_defaults "$WORKDIR"
+
+SESSION="${WAKE_LOOP_SESSION:-codex_wake_loop}"
 INTERVAL_SECS="${WAKE_POLL_SECS:-30}"
 WATCH_ROOMS="${AGORA_WAKE_ROOMS:-collab plaza local-sync}"
 LOG_FILE="${WAKE_LOOP_LOG:-$WORKDIR/.wake/${SESSION}.log}"
+AGORA_ENV_FILE="$(resolve_agora_env_file "$WORKDIR")"
 
 usage() {
     cat <<'EOF'
@@ -19,6 +24,7 @@ Environment:
   WAKE_WORKDIR        repo path containing wake-loop.sh
   WAKE_POLL_SECS      polling interval in seconds (default: 30)
   AGORA_WAKE_ROOMS    space/comma-separated rooms to watch (default: collab plaza local-sync)
+  AGORA_ENV_FILE      defaults file for helper-script env (default: <workdir>/.agora-env)
   WAKE_LOOP_LOG       log file path (default: <workdir>/.wake/<session>.log)
 EOF
 }
@@ -40,9 +46,10 @@ fi
 mkdir -p "$(dirname "$LOG_FILE")"
 
 tmux new-session -d -s "$SESSION" \
-    "cd '$WORKDIR' && export WAKE_POLL_SECS='$INTERVAL_SECS' AGORA_WAKE_ROOMS='$WATCH_ROOMS' && ./wake-loop.sh >> '$LOG_FILE' 2>&1"
+    "cd '$WORKDIR' && export AGORA_ENV_FILE='$AGORA_ENV_FILE' WAKE_POLL_SECS='$INTERVAL_SECS' AGORA_WAKE_ROOMS='$WATCH_ROOMS' && ./wake-loop.sh >> '$LOG_FILE' 2>&1"
 
 echo "[start-wake-loop] session:  $SESSION"
 echo "[start-wake-loop] interval: ${INTERVAL_SECS}s"
 echo "[start-wake-loop] rooms:    $WATCH_ROOMS"
+echo "[start-wake-loop] env file: $AGORA_ENV_FILE"
 echo "[start-wake-loop] log:      $LOG_FILE"

--- a/wake-loop.sh
+++ b/wake-loop.sh
@@ -5,6 +5,11 @@
 
 set -euo pipefail
 
+WORKDIR="${WAKE_WORKDIR:-$(pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/agora-env.sh"
+load_agora_env_defaults "$WORKDIR"
+
 INTERVAL_SECS="${WAKE_POLL_SECS:-120}"
 WAKE_BRIDGE="${WAKE_BRIDGE:-./wake-on-agora.sh}"
 WATCH_ROOMS="${AGORA_WAKE_ROOMS:-all joined rooms}"

--- a/wake-on-agora.sh
+++ b/wake-on-agora.sh
@@ -14,6 +14,11 @@
 
 set -euo pipefail
 
+WORKDIR="${WAKE_WORKDIR:-$(pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/agora-env.sh"
+load_agora_env_defaults "$WORKDIR"
+
 AGORA="${AGORA_BIN:-./target/release/agora}"
 WAKE_SCRIPT="${WAKE_SCRIPT:-./wake-codex.sh}"
 SOURCE_THREAD="${CODEX_SOURCE_THREAD:-019d5e1a-b68c-70f2-b361-c6ba36537dd1}"
@@ -31,6 +36,7 @@ Environment:
   AGORA_NOTIFY_SINCE   Lookback window passed to local cache logic
   AGORA_WORKER_ID      Agora identity for the forked worker and notifier
   AGORA_WAKE_ROOMS     Space/comma-separated room labels to watch
+  AGORA_ENV_FILE       defaults file for helper-script env (default: <workdir>/.agora-env)
   MAIN_CODEX_PANE      tmux pane target for the main local Codex session
 EOF
 }

--- a/worker-agora.sh
+++ b/worker-agora.sh
@@ -4,6 +4,10 @@
 set -euo pipefail
 
 WORKDIR="${WORKDIR:-$(pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/agora-env.sh"
+load_agora_env_defaults "$WORKDIR"
+
 AGORA_BIN="${AGORA_BIN:-$WORKDIR/target/release/agora}"
 BASE_HOME="${BASE_HOME:-$HOME}"
 WORKER_HOME="${WORKER_HOME:-$WORKDIR/.worker-home}"


### PR DESCRIPTION
## Summary
- add a small `agora-env.sh` helper so local wake/worker scripts can share simple `KEY=value` defaults from `.agora-env`
- make `start-wake-loop`, `wake-loop`, `wake-on-agora`, and `worker-agora` load that defaults file before deriving relay and room settings
- document the new `.agora-env` pattern for keeping the worker wake stack aligned with the configured relay during migration

## Validation
- `bash -n agora-env.sh start-wake-loop.sh wake-loop.sh wake-on-agora.sh worker-agora.sh`
- helper-defaults smoke check with `.tmp-env`
- `AGORA_ENV_FILE=$(pwd)/.tmp-env ./start-wake-loop.sh` (verified env-file propagation and then restored the real main-checkout wake loop)
