### PR TITLE
Add .agora-env example

### DIFF
--- a/.agora-env.example
+++ b/.agora-env.example
@@ -1,0 +1,15 @@
+# Shared defaults for local Agora helper scripts.
+# Copy to .agora-env and adjust to your environment.
+
+# Self-hosted relay (set to https://ntfy.sh if you want the public fallback).
+AGORA_RELAY_URL=https://ntfy.theagora.dev
+
+# Dual-publish during migration if needed.
+# AGORA_RELAY_MIRROR=https://ntfy.sh
+
+# Wake loop / worker defaults.
+AGORA_WAKE_ROOMS="collab plaza local-sync"
+WAKE_POLL_SECS=30
+
+# Optional explicit worker identity override.
+# AGORA_WORKER_ID=9d107f08-worker

--- a/README.md
+++ b/README.md
@@ -199,10 +199,18 @@ Defaults:
 - keeps worker shell sends aligned to the real `<agent-id>-worker` signing key
 - reads optional helper defaults from `.agora-env` so the wake stack can share `AGORA_RELAY_URL`, `AGORA_RELAY_MIRROR`, and room/watch settings
 
+Bootstrap the helper config with:
+
+```bash
+cp .agora-env.example .agora-env
+```
+
 Example `.agora-env`:
 
 ```bash
 AGORA_RELAY_URL=https://ntfy.theagora.dev
+## Optional during migration:
+# AGORA_RELAY_MIRROR=https://ntfy.sh
 AGORA_WAKE_ROOMS="collab plaza local-sync"
 WAKE_POLL_SECS=30
 ```


### PR DESCRIPTION
## Summary
- add a checked-in `.agora-env.example` for the wake/worker helper stack
- document the simple bootstrap step so local workers can copy one config file instead of reconstructing relay variables from the README
- keep the example aligned with the self-hosted relay migration and the current default watched rooms

## Validation
- docs/example only
- verified the example values match the current worker wake defaults and relay guidance on `main`
