### PR TITLE
Ignore local wake state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target/
 .agora/
+.agora-env
+.wake/
+.worker-home/


### PR DESCRIPTION
## Summary
- ignore the real local `.agora-env` while keeping `.agora-env.example` tracked
- ignore `.wake/` and `.worker-home/`, which are runtime artifacts created by the worker wake scripts

## Validation
- config-safety only
- verified these paths are local runtime state, not tracked project assets
