### PR TITLE
Document and harden relay auth support

### DIFF
--- a/.agora-env.example
+++ b/.agora-env.example
@@ -3,6 +3,8 @@
 
 # Self-hosted relay (set to https://ntfy.sh if you want the public fallback).
 AGORA_RELAY_URL=https://ntfy.theagora.dev
+# Optional bearer token for a private relay.
+# AGORA_RELAY_TOKEN=replace-me
 
 # Dual-publish during migration if needed.
 # AGORA_RELAY_MIRROR=https://ntfy.sh

--- a/README.md
+++ b/README.md
@@ -158,10 +158,18 @@ Agora defaults to `https://ntfy.sh`, but the relay is configurable:
 export AGORA_RELAY_URL=https://ntfy.theagora.dev
 ```
 
+For a private relay, configure a bearer token locally:
+
+```bash
+export AGORA_RELAY_URL=https://ntfy.theagora.dev
+export AGORA_RELAY_TOKEN=replace-me
+```
+
 For zero-downtime relay migration, dual-publish during the cutover:
 
 ```bash
 export AGORA_RELAY_URL=https://ntfy.theagora.dev
+export AGORA_RELAY_TOKEN=replace-me
 export AGORA_RELAY_MIRROR=https://ntfy.sh
 ```
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -7,6 +7,9 @@
 //!   AGORA_RELAY_URL=https://ntfy.theagora.dev  (custom relay)
 //!   Default: https://ntfy.sh
 //!
+//! Optional relay auth:
+//!   AGORA_RELAY_TOKEN=...  (sent as Authorization: Bearer ...)
+//!
 //! Dual-publish for zero-downtime migration:
 //!   AGORA_RELAY_MIRROR=https://ntfy.sh  (publish to both during transition)
 
@@ -75,7 +78,9 @@ pub fn publish(topic: &str, payload: &str) -> bool {
     // Dual-publish to mirror for zero-downtime migration
     if let Some(mirror) = mirror_url() {
         let mirror_url = format!("{mirror}/{topic}");
-        let _ = client().post(&mirror_url).body(payload.to_string()).send();
+        let _ = apply_auth(client().post(&mirror_url))
+            .body(payload.to_string())
+            .send();
     }
 
     ok
@@ -151,7 +156,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{mirror_url, relay_status_label, relay_url, DEFAULT_RELAY};
+    use super::{mirror_url, relay_status_label, relay_token, relay_url, DEFAULT_RELAY};
     use crate::store;
 
     fn restore_env(name: &str, value: Option<String>) {
@@ -194,6 +199,19 @@ mod tests {
         assert_eq!(mirror_url(), Some("https://ntfy.sh".to_string()));
 
         restore_env("AGORA_RELAY_MIRROR", prior);
+    }
+
+    #[test]
+    fn relay_token_is_optional() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let prior = std::env::var("AGORA_RELAY_TOKEN").ok();
+        unsafe { std::env::remove_var("AGORA_RELAY_TOKEN") };
+        assert_eq!(relay_token(), None);
+
+        unsafe { std::env::set_var("AGORA_RELAY_TOKEN", "relay-secret") };
+        assert_eq!(relay_token(), Some("relay-secret".to_string()));
+
+        restore_env("AGORA_RELAY_TOKEN", prior);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- document `AGORA_RELAY_TOKEN` in the relay setup docs and `.agora-env.example`
- add a transport test for the relay token env knob
- apply relay auth to mirror publish as well, so dual-publish still works when both relays are private

## Validation
- `TMPDIR=$(pwd)/.tmp-tests CARGO_TARGET_DIR=$(pwd)/target-tmp cargo test transport::tests::`
- `TMPDIR=$(pwd)/.tmp-tests CARGO_TARGET_DIR=$(pwd)/target-tmp cargo build --release`
