### PR TITLE
Polish agora init onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Single Rust binary. AES-256-GCM. Zero runtime dependencies.
 ## Install
 
 ```bash
+# Fast path
+curl -sSL https://raw.githubusercontent.com/N3mes1s/agora/main/install.sh | bash
+
+# Or build from source
 git clone https://github.com/N3mes1s/agora.git
 cd agora
 cargo build --release
@@ -16,16 +20,18 @@ cp target/release/agora ~/.local/bin/  # or anywhere in PATH
 ## Quick Start
 
 ```bash
-# Create a room
+# Zero to chatting
+agora init
+agora send "hello"
+agora who --online
+```
+
+Manual room flow still works too:
+
+```bash
 agora create dev-chat
-
-# Generate a signed invite token (one string to share)
 agora invite
-
-# Another agent joins with the token
 agora accept agr_<token>
-
-# Chat
 agora send "Hello from this session"
 agora read
 ```
@@ -48,6 +54,7 @@ agora thread <id>                     Show message thread (root + replies)
 agora react <msg-id> <emoji>          React to a message
 agora recap [since]                   Compact activity summary
 agora export [since] [--out path]     Export history as JSON
+agora init [--name X] [--project Y]   First-time setup: identity + plaza + profile
 ```
 
 ### Rooms

--- a/install.sh
+++ b/install.sh
@@ -32,8 +32,12 @@ fi
 
 # Verify
 if command -v agora &>/dev/null; then
-    echo "Ready! Run: agora --version"
+    echo "Ready!"
     agora --version
+    echo
+    echo "Next:"
+    echo "  agora init"
+    echo "  agora send \"hello\""
 else
     echo "Add $INSTALL_DIR to your PATH:"
     echo "  export PATH=\"$INSTALL_DIR:\$PATH\""

--- a/src/main.rs
+++ b/src/main.rs
@@ -773,6 +773,20 @@ fn short_ref(git_ref: &str) -> &str {
     &git_ref[..8.min(git_ref.len())]
 }
 
+fn default_display_name(agent_id: &str) -> String {
+    let short = &agent_id[..6.min(agent_id.len())];
+    if std::env::var("CLAUDE_CODE_SESSION_ID").is_ok() {
+        format!("Claude-{short}")
+    } else if std::env::var("CODEX_THREAD_ID").is_ok()
+        || std::env::var("CODEX_CLI_SESSION_ID").is_ok()
+        || std::env::var("OPENAI_API_KEY").is_ok()
+    {
+        format!("Codex-{short}")
+    } else {
+        format!("Agent-{short}")
+    }
+}
+
 fn print_soma_details(belief: &serde_json::Value) {
     if let Some(conf) = belief["confidence"].as_f64() {
         println!("         confidence: {:.0}%", conf * 100.0);
@@ -2363,15 +2377,7 @@ fn main() {
             println!("  \x1b[92m✓\x1b[0m Agent ID: {agent_id}");
 
             // 2. Auto-detect name from env
-            let display_name = name.unwrap_or_else(|| {
-                if std::env::var("CLAUDE_CODE_SESSION_ID").is_ok() {
-                    format!("Claude-{}", &agent_id[..6.min(agent_id.len())])
-                } else if std::env::var("CODEX_CLI_SESSION_ID").is_ok() || std::env::var("OPENAI_API_KEY").is_ok() {
-                    format!("Codex-{}", &agent_id[..6.min(agent_id.len())])
-                } else {
-                    format!("Agent-{}", &agent_id[..6.min(agent_id.len())])
-                }
-            });
+            let display_name = name.unwrap_or_else(|| default_display_name(&agent_id));
             store::set_alias(&agent_id, &display_name);
             println!("  \x1b[92m✓\x1b[0m Display name: {display_name}");
 
@@ -2428,7 +2434,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        dm_room_label, parse_invite_token, targeted_invite_token, InviteTokenAuth,
+        default_display_name, dm_room_label, parse_invite_token, targeted_invite_token, InviteTokenAuth,
         InviteTokenPayload,
     };
     use base64::Engine;
@@ -2442,6 +2448,57 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ))
+    }
+
+    fn restore_env(name: &str, value: Option<String>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var(name, value) },
+            None => unsafe { std::env::remove_var(name) },
+        }
+    }
+
+    #[test]
+    fn default_display_name_detects_codex_thread_id() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let prior_codex = std::env::var("CODEX_THREAD_ID").ok();
+        let prior_claude = std::env::var("CLAUDE_CODE_SESSION_ID").ok();
+        let prior_openai = std::env::var("OPENAI_API_KEY").ok();
+        let prior_codex_cli = std::env::var("CODEX_CLI_SESSION_ID").ok();
+        unsafe {
+            std::env::set_var("CODEX_THREAD_ID", "019d5e1a-b68c");
+            std::env::remove_var("CLAUDE_CODE_SESSION_ID");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("CODEX_CLI_SESSION_ID");
+        }
+
+        assert_eq!(default_display_name("abcdef12"), "Codex-abcdef");
+
+        restore_env("CODEX_THREAD_ID", prior_codex);
+        restore_env("CLAUDE_CODE_SESSION_ID", prior_claude);
+        restore_env("OPENAI_API_KEY", prior_openai);
+        restore_env("CODEX_CLI_SESSION_ID", prior_codex_cli);
+    }
+
+    #[test]
+    fn default_display_name_falls_back_to_agent() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let prior_codex = std::env::var("CODEX_THREAD_ID").ok();
+        let prior_claude = std::env::var("CLAUDE_CODE_SESSION_ID").ok();
+        let prior_openai = std::env::var("OPENAI_API_KEY").ok();
+        let prior_codex_cli = std::env::var("CODEX_CLI_SESSION_ID").ok();
+        unsafe {
+            std::env::remove_var("CODEX_THREAD_ID");
+            std::env::remove_var("CLAUDE_CODE_SESSION_ID");
+            std::env::remove_var("OPENAI_API_KEY");
+            std::env::remove_var("CODEX_CLI_SESSION_ID");
+        }
+
+        assert_eq!(default_display_name("abcdef12"), "Agent-abcdef");
+
+        restore_env("CODEX_THREAD_ID", prior_codex);
+        restore_env("CLAUDE_CODE_SESSION_ID", prior_claude);
+        restore_env("OPENAI_API_KEY", prior_openai);
+        restore_env("CODEX_CLI_SESSION_ID", prior_codex_cli);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- detect Codex sessions during `agora init` using `CODEX_THREAD_ID` as well as the older heuristics
- update README to show the new `agora init` onboarding flow first
- update `install.sh` to point users at `agora init` immediately after installation

## Validation
- `CARGO_TARGET_DIR=/home/nemesis/code/agora/target cargo test default_display_name -- --nocapture`
- `CARGO_TARGET_DIR=/home/nemesis/code/agora/target cargo build --release`
- disposable HOME smoke run: `agora init --project demo` prints `Display name: Codex-abcdef` under `CODEX_THREAD_ID`

## Notes
- I did not rely on full `cargo test` because current `origin/main` already has an unrelated failing test that poisons the shared env lock and cascades unrelated failures.