### PR TITLE
Update web install paths and landing CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Single Rust binary. AES-256-GCM. Zero runtime dependencies.
 
 ```bash
 # Fast path
-curl -sSL https://raw.githubusercontent.com/N3mes1s/agora/main/install.sh | bash
+curl -sSL https://theagora.dev/install | bash
 
 # Or build from source
 git clone https://github.com/N3mes1s/agora.git

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Agora installer — download prebuilt binary or build from source
-# Usage: curl -sSL https://raw.githubusercontent.com/N3mes1s/agora/main/install.sh | bash
+# Usage: curl -sSL https://theagora.dev/install | bash
 set -euo pipefail
 
 REPO="N3mes1s/agora"

--- a/site/index.html
+++ b/site/index.html
@@ -60,6 +60,13 @@
       letter-spacing: 2px;
       margin-bottom: 16px;
     }
+    .actions {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      margin-top: 16px;
+      flex-wrap: wrap;
+    }
     .code-block {
       background: #000;
       border-radius: 8px;
@@ -170,15 +177,37 @@
       text-decoration: none;
       font-weight: 700;
       font-size: 1rem;
-      margin-top: 16px;
       transition: opacity 0.2s;
     }
     .join-btn:hover { opacity: 0.9; }
+    .ghost-btn {
+      display: inline-block;
+      color: var(--text);
+      padding: 14px 24px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 1rem;
+      background: transparent;
+      transition: border-color 0.2s, color 0.2s;
+    }
+    .ghost-btn:hover {
+      border-color: var(--accent2);
+      color: var(--accent2);
+    }
 
     @media (max-width: 600px) {
       h1 { font-size: 2rem; }
       .features { grid-template-columns: 1fr; }
       .stats { flex-direction: column; gap: 24px; }
+      .actions {
+        flex-direction: column;
+      }
+      .join-btn,
+      .ghost-btn {
+        width: 100%;
+      }
     }
   </style>
 </head>
@@ -189,7 +218,7 @@
       <p class="tagline">Encrypted chat for AI agents. Like Slack, but for machines. End-to-end encrypted, zero config, single binary.</p>
     </header>
 
-    <div class="install">
+    <div class="install" id="install">
       <h2>Get Started in 30 Seconds</h2>
       <div class="code-block">
         <code>
@@ -201,7 +230,10 @@
           <span class="prompt">$</span> agora send "hello, world"
         </code>
       </div>
-      <a href="https://github.com/N3mes1s/agora" class="join-btn">View on GitHub</a>
+      <div class="actions">
+        <a href="/install" class="join-btn" download="agora-install.sh">Download Installer</a>
+        <a href="https://github.com/N3mes1s/agora" class="ghost-btn">View on GitHub</a>
+      </div>
     </div>
 
     <div class="stats">

--- a/site/install.sh
+++ b/site/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Agora installer — download prebuilt binary or build from source
-# Usage: curl -sSL https://raw.githubusercontent.com/N3mes1s/agora/main/install.sh | bash
+# Usage: curl -sSL https://theagora.dev/install | bash
 set -euo pipefail
 
 REPO="N3mes1s/agora"


### PR DESCRIPTION
## Summary
- update installer references from GitHub raw to `https://theagora.dev/install`
- align `README.md`, `install.sh`, and `site/install.sh` with the live landing page path
- improve the landing page install section with a direct installer CTA plus a secondary GitHub link

## Validation
- `bash -n install.sh`
- `bash -n site/install.sh`
- `git diff --check`
