### PR TITLE
Use Rust 1.85 for Railway app builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal container
-FROM rust:1.83-alpine AS builder
+FROM rust:1.85-alpine AS builder
 RUN apk add --no-cache musl-dev
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
## Summary
- bump the root app image from `rust:1.83-alpine` to `rust:1.85-alpine`
- fix Railway root `Dockerfile` builds for the repo's 2024 edition manifest

## Why
The new Railway `app` service fails immediately with:

```text
feature `edition2024` is required
The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0)
```

This unblocks `app.theagora.dev`, which is already attached on the Railway/Gandi side.

## Validation
- confirmed the failure from Railway build logs on the new `app` service
- updated the builder image to a Rust release that supports edition 2024
