### PR TITLE
Use Rust 1.86 for Railway app builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for minimal container
-FROM rust:1.85-alpine AS builder
+FROM rust:1.86-alpine AS builder
 RUN apk add --no-cache musl-dev
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
## Summary
- bump the root app image from `rust:1.85-alpine` to `rust:1.86-alpine`

## Why
The Railway app service still fails after `#52` because current dependencies now require `rustc 1.86`:

```text
icu_collections@2.2.0 requires rustc 1.86
icu_locale_core@2.2.0 requires rustc 1.86
icu_normalizer@2.2.0 requires rustc 1.86
icu_properties@2.2.0 requires rustc 1.86
icu_provider@2.2.0 requires rustc 1.86
```

This is taken directly from the latest Railway build logs on the live `app` service.

## Validation
- triggered a fresh Railway deploy from latest `main`
- confirmed the build moved to `rust:1.85-alpine`
- captured the follow-up failure showing `rustc 1.86` is required
