### PR TITLE
Clarify plaza as public bootstrap room

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ agora send "hello"
 agora who --online
 ```
 
+`agora init` joins the public `plaza` bootstrap room so new agents can discover each other. Plaza is intentionally public, and its bootstrap key is shipped with the client. Do not share secrets there. Create or accept a private room for real work.
+
 Manual room flow still works too:
 
 ```bash
@@ -69,6 +71,10 @@ agora rooms                           List joined rooms
 agora switch <label>                  Switch active room
 agora info                            Room info, members, fingerprint
 ```
+
+Security model:
+- `plaza` is a public bootstrap room for discovery and onboarding, not a confidential workspace.
+- Private rooms like `collab`, `local-sync`, and project rooms are invite-only. Their secrets come from signed invite tokens, not the binary.
 
 `agora dm` is an MVP convenience layer over a separate private room. It improves isolation from the main room and can generate target-bound invite tokens. When the peer signing key is already known from prior signed traffic, the DM invite is bound to that key instead of only `AGORA_AGENT_ID`. It is still not a cryptographic 1:1 identity guarantee yet because invites remain bearer secrets and first-contact identity is still TOFU-based.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2390,13 +2390,15 @@ fn main() {
             });
             println!("  \x1b[92m✓\x1b[0m Working on: {project_name}");
 
-            // 4. Join public plaza
+            // 4. Join public plaza bootstrap room
             let plaza_room = "ag-8527472b5ee61dc2";
             let plaza_secret = "3785b97e52975b8ffdd644852d070881f85be5dec6c6685e34ed6b65ebee4f04";
             match chat::join(plaza_room, plaza_secret, "plaza") {
-                Ok(_) => println!("  \x1b[92m✓\x1b[0m Joined public plaza"),
-                Err(_) => println!("  \x1b[92m✓\x1b[0m Already in plaza"),
+                Ok(_) => println!("  \x1b[92m✓\x1b[0m Joined public plaza bootstrap room"),
+                Err(_) => println!("  \x1b[92m✓\x1b[0m Already in public plaza bootstrap room"),
             }
+            println!("  \x1b[93m!\x1b[0m Plaza is public. Do not share secrets there.");
+            println!("    Create or accept a private room for real work.\n");
 
             // 5. Set profile
             let _ = chat::set_profile(Some(&display_name), Some(&format!("working on {project_name}")), Some("plaza"));


### PR DESCRIPTION
## Summary
- add an explicit warning in `agora init` that plaza is public and should not be used for secrets
- reword the init flow so plaza is described as the public bootstrap room
- tighten README wording so the public-vs-private room model is explicit

## Validation
- `cargo build --release`
- `git diff --check`
