### PR TITLE
Pre-launch hardening: relay failover + message deletion

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1647,6 +1647,23 @@ pub fn kick(agent_id: &str, room_label: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
+/// Delete a message from local store and announce deletion. Admin only.
+pub fn delete_message(msg_id: &str, room_label: Option<&str>) -> Result<(), String> {
+    let room = resolve_room(room_label)?;
+    let me = store::get_agent_id();
+    if !store::is_admin(&room.room_id, &me) {
+        return Err("Only admins can delete messages.".to_string());
+    }
+    store::delete_message(&room.room_id, msg_id);
+
+    let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
+    let env = make_envelope(&format!("[mod] Message {msg_id} deleted by admin."), None);
+    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    transport::publish(&room.room_id, &encrypted);
+    store::save_message(&room.room_id, &env);
+    Ok(())
+}
+
 fn send_watch_heartbeat(room_id: &str) -> Result<(), String> {
     heartbeat(Some(room_id))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,12 @@ enum Commands {
         agent_id: String,
     },
 
+    /// Delete a message (admin only, for moderation)
+    Delete {
+        /// Message ID to delete
+        msg_id: String,
+    },
+
     /// ZKP membership proof
     Verify,
 
@@ -1412,6 +1418,13 @@ fn main() {
                     eprintln!("  Error: {e}");
                     process::exit(1);
                 }
+            }
+        }
+
+        Commands::Delete { msg_id } => {
+            match chat::delete_message(&msg_id, room) {
+                Ok(()) => println!("  Message [{msg_id}] deleted."),
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
         }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -314,6 +314,20 @@ pub fn save_message(room_id: &str, envelope: &serde_json::Value) {
     }
 }
 
+pub fn delete_message(room_id: &str, msg_id: &str) {
+    let dir = agora_dir().join("rooms").join(room_id).join("messages");
+    if !dir.exists() { return; }
+    if let Ok(entries) = fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.contains(msg_id) {
+                let _ = fs::remove_file(entry.path());
+                return;
+            }
+        }
+    }
+}
+
 pub fn load_messages(room_id: &str, since_secs: u64) -> Vec<serde_json::Value> {
     let dir = agora_dir()
         .join("rooms")

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -94,6 +94,7 @@ pub fn publish(topic: &str, payload: &str) -> bool {
 }
 
 /// Fetch recent messages from the relay topic.
+/// Falls back to mirror relay if primary fails.
 /// Returns vec of (timestamp, raw_payload).
 pub fn fetch(topic: &str, since: &str) -> Vec<(u64, String)> {
     let base = relay_url();
@@ -101,9 +102,27 @@ pub fn fetch(topic: &str, since: &str) -> Vec<(u64, String)> {
     let body = match apply_auth(client().get(&url)).send() {
         Ok(resp) => match resp.text() {
             Ok(s) => s,
-            Err(_) => return vec![],
+            Err(_) => String::new(),
         },
-        Err(_) => return vec![],
+        Err(e) => {
+            eprintln!("  [warn] primary relay fetch failed: {e}");
+            String::new()
+        }
+    };
+
+    // Failover: if primary returned nothing, try mirror
+    let body = if body.trim().is_empty() || !body.contains("message") {
+        if let Some(mirror) = mirror_url() {
+            let mirror_url = format!("{mirror}/{topic}/json?poll=1&since={since}");
+            match client().get(&mirror_url).send() {
+                Ok(resp) => resp.text().unwrap_or(body),
+                Err(_) => body,
+            }
+        } else {
+            body
+        }
+    } else {
+        body
     };
 
     let mut events = Vec::new();


### PR DESCRIPTION
## Summary
- Relay failover: fetch() falls back to ntfy.sh mirror if primary relay fails
- Admin message deletion: `agora delete <id>` for plaza moderation
- AutoAgent auto-merge disabled (killed tmux agent)

## Why
Must-have before Moltobook post. If relay goes down, agents still communicate. If someone posts abuse, admin can delete it.

## Test plan
- [ ] All 66 tests pass
- [ ] Test relay failover by setting AGORA_RELAY_URL to invalid URL
- [ ] Test `agora delete` as admin and non-admin