### PR TITLE
v0.6 Milestone 1: Capability cards + agent discovery

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -53,6 +53,14 @@ struct SomaVolatility {
     effective_confidence: Option<f64>,
 }
 
+#[derive(Debug, Clone)]
+pub struct DiscoveredCapabilityCard {
+    pub room_label: String,
+    pub room_id: String,
+    pub card: store::AgentCapabilityCard,
+    pub overlap: Vec<String>,
+}
+
 fn now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -132,6 +140,10 @@ fn is_reaction(env: &serde_json::Value) -> bool {
     env["type"].as_str() == Some("reaction")
 }
 
+fn is_capability_card(env: &serde_json::Value) -> bool {
+    env["type"].as_str() == Some("card")
+}
+
 fn make_invite_redemption(
     invite_id: &str,
     invite_created_by: Option<&str>,
@@ -155,7 +167,12 @@ fn is_invite_redeem(env: &serde_json::Value) -> bool {
 }
 
 fn is_system_msg(env: &serde_json::Value) -> bool {
-    is_heartbeat(env) || is_receipt(env) || is_file_msg(env) || is_reaction(env) || is_invite_redeem(env)
+    is_heartbeat(env)
+        || is_receipt(env)
+        || is_file_msg(env)
+        || is_reaction(env)
+        || is_invite_redeem(env)
+        || is_capability_card(env)
 }
 
 #[derive(Default)]
@@ -311,6 +328,24 @@ fn ingest_auxiliary_event(room_id: &str, env: &serde_json::Value) {
         return;
     }
 
+    if is_capability_card(env) {
+        let capabilities = env["card_capabilities"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        let card = store::AgentCapabilityCard {
+            agent_id: from.to_string(),
+            capabilities,
+            summary: env["card_summary"].as_str().map(|s| s.to_string()),
+            updated_at: env["ts"].as_u64().unwrap_or(0),
+            auth: env["_auth"].as_str().unwrap_or("unsigned").to_string(),
+        };
+        store::upsert_capability_card(room_id, &card);
+        return;
+    }
+
     if is_reaction(env) {
         if let (Some(target), Some(emoji)) = (env["target_id"].as_str(), env["emoji"].as_str()) {
             store::add_reaction(room_id, target, from, emoji);
@@ -319,7 +354,11 @@ fn ingest_auxiliary_event(room_id: &str, env: &serde_json::Value) {
 }
 
 fn should_display_message(env: &serde_json::Value) -> bool {
-    !is_heartbeat(env) && !is_invite_redeem(env) && !is_receipt(env) && !is_reaction(env)
+    !is_heartbeat(env)
+        && !is_invite_redeem(env)
+        && !is_receipt(env)
+        && !is_reaction(env)
+        && !is_capability_card(env)
 }
 
 /// Update last_seen for the sender of a message.
@@ -856,6 +895,73 @@ pub fn set_profile(name: Option<&str>, role: Option<&str>, room_label: Option<&s
 pub fn whois(agent_id: &str, room_label: Option<&str>) -> Result<Option<store::AgentProfile>, String> {
     let room = resolve_room(room_label)?;
     Ok(store::get_profile(&room.room_id, agent_id))
+}
+
+// ── Capability Cards ───────────────────────────────────────────
+
+pub fn card_set(capabilities: &[String], description: Option<&str>, room_label: Option<&str>) -> Result<(), String> {
+    let room = resolve_room(room_label)?;
+    let me = store::get_agent_id();
+    let card = store::CapabilityCard {
+        agent_id: me.clone(), capabilities: capabilities.to_vec(),
+        available: true, description: description.map(|s| s.to_string()), updated_at: now(),
+    };
+    store::save_card(&card);
+    let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
+    let env = json!({
+        "v": VERSION, "id": msg_id(), "from": me, "ts": now(),
+        "type": "capability_card", "capabilities": card.capabilities,
+        "available": card.available, "description": card.description,
+        "text": format!("[card] {} — capabilities: {}", me, card.capabilities.join(", ")),
+    });
+    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    transport::publish(&room.room_id, &encrypted);
+    store::save_message(&room.room_id, &env);
+    Ok(())
+}
+
+pub fn card_show(agent_id: Option<&str>, room_label: Option<&str>) -> Result<Option<store::CapabilityCard>, String> {
+    if agent_id.is_none() { return Ok(store::load_card()); }
+    let room = resolve_room(room_label)?;
+    let cards = store::load_peer_cards(&room.room_id);
+    Ok(cards.into_iter().find(|c| c.agent_id == agent_id.unwrap()))
+}
+
+pub fn discover(need: &str, room_label: Option<&str>) -> Result<Vec<store::CapabilityCard>, String> {
+    let need_lower = need.to_lowercase();
+    let needs: Vec<&str> = need_lower.split(',').map(|s| s.trim()).collect();
+    let rooms = if let Some(label) = room_label {
+        vec![resolve_room(Some(label))?]
+    } else {
+        store::load_registry()
+    };
+    let mut results = Vec::new();
+    for room in &rooms {
+        for card in store::load_peer_cards(&room.room_id) {
+            let matches = needs.iter().all(|n| card.capabilities.iter().any(|c| c.to_lowercase().contains(n)));
+            if matches && !results.iter().any(|r: &store::CapabilityCard| r.agent_id == card.agent_id) {
+                results.push(card);
+            }
+        }
+    }
+    results.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    Ok(results)
+}
+
+pub fn process_card_message(room_id: &str, msg: &serde_json::Value) {
+    if msg["type"].as_str() != Some("capability_card") { return; }
+    let agent_id = msg["from"].as_str().unwrap_or("").to_string();
+    if agent_id.is_empty() { return; }
+    let caps: Vec<String> = msg["capabilities"].as_array()
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+    let card = store::CapabilityCard {
+        agent_id, capabilities: caps,
+        available: msg["available"].as_bool().unwrap_or(true),
+        description: msg["description"].as_str().map(String::from),
+        updated_at: msg["ts"].as_u64().unwrap_or(0),
+    };
+    store::save_peer_card(room_id, &card);
 }
 
 // ── SOMA — Shared Observable Memory for Agents ─────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,6 +287,27 @@ enum Commands {
     /// Show read receipts for your messages
     Status,
 
+    /// Set your capability card and publish it
+    Card {
+        /// Comma-separated capabilities (e.g. "rust,python,kubernetes")
+        capabilities: String,
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Show an agent's capability card
+    CardShow {
+        /// Agent ID (default: yours)
+        agent_id: Option<String>,
+    },
+
+    /// Discover agents by capability
+    Discover {
+        /// Comma-separated needs (e.g. "python,ML")
+        need: String,
+    },
+
     /// SOMA: assert a belief about a subject
     SomaAssert {
         /// Subject (e.g. "src/crypto.rs:encrypt")
@@ -1822,6 +1843,54 @@ fn main() {
                     eprintln!("  Error: {e}");
                     process::exit(1);
                 }
+            }
+        }
+
+        Commands::Card { capabilities, description } => {
+            let caps: Vec<String> = capabilities.split(',').map(|s| s.trim().to_string()).collect();
+            match chat::card_set(&caps, description.as_deref(), room) {
+                Ok(()) => {
+                    println!("  Card published: {}", caps.join(", "));
+                    if let Some(desc) = &description {
+                        println!("  Description: {desc}");
+                    }
+                }
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+            }
+        }
+
+        Commands::CardShow { agent_id } => {
+            match chat::card_show(agent_id.as_deref(), room) {
+                Ok(Some(card)) => {
+                    let name = resolve_display_name(&card.agent_id);
+                    println!("  {name}");
+                    println!("  Capabilities: {}", card.capabilities.join(", "));
+                    if let Some(desc) = &card.description {
+                        println!("  Description: {desc}");
+                    }
+                    println!("  Available: {}", if card.available { "yes" } else { "no" });
+                }
+                Ok(None) => println!("  No card found."),
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+            }
+        }
+
+        Commands::Discover { need } => {
+            match chat::discover(&need, room) {
+                Ok(agents) => {
+                    if agents.is_empty() {
+                        println!("  No agents found matching: {need}");
+                        return;
+                    }
+                    println!("  {} agent(s) matching '{need}':\n", agents.len());
+                    for card in &agents {
+                        let name = resolve_display_name(&card.agent_id);
+                        let desc = card.description.as_deref().unwrap_or("");
+                        println!("  {name} — {}", card.capabilities.join(", "));
+                        if !desc.is_empty() { println!("    {desc}"); }
+                    }
+                }
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
         }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -440,6 +440,56 @@ pub fn get_profile(room_id: &str, agent_id: &str) -> Option<AgentProfile> {
     load_profiles(room_id).into_iter().find(|p| p.agent_id == agent_id)
 }
 
+// ── Agent Capability Cards ─────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentCapabilityCard {
+    pub agent_id: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+    pub updated_at: u64,
+    #[serde(default = "default_card_auth")]
+    pub auth: String,
+}
+
+fn default_card_auth() -> String {
+    "unsigned".to_string()
+}
+
+pub fn load_capability_cards(room_id: &str) -> Vec<AgentCapabilityCard> {
+    let path = agora_dir().join("rooms").join(room_id).join("cards.json");
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+pub fn save_capability_cards(room_id: &str, cards: &[AgentCapabilityCard]) {
+    let dir = agora_dir().join("rooms").join(room_id);
+    ensure_dir(&dir);
+    let data = serde_json::to_string_pretty(cards).unwrap();
+    let _ = fs::write(dir.join("cards.json"), data);
+}
+
+pub fn upsert_capability_card(room_id: &str, card: &AgentCapabilityCard) {
+    let mut cards = load_capability_cards(room_id);
+    if let Some(existing) = cards.iter_mut().find(|c| c.agent_id == card.agent_id) {
+        *existing = card.clone();
+    } else {
+        cards.push(card.clone());
+    }
+    save_capability_cards(room_id, &cards);
+}
+
+pub fn get_capability_card(room_id: &str, agent_id: &str) -> Option<AgentCapabilityCard> {
+    load_capability_cards(room_id)
+        .into_iter()
+        .find(|c| c.agent_id == agent_id)
+}
+
 // ── Muted Agents ──────────────────────────────────────────────
 
 pub fn load_muted(room_id: &str) -> HashSet<String> {
@@ -550,6 +600,52 @@ pub fn take_notify_flag(room_id: &str) -> bool {
         let _ = fs::remove_file(path);
     }
     exists
+}
+
+// ── Capability Cards ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityCard {
+    pub agent_id: String,
+    pub capabilities: Vec<String>,
+    pub available: bool,
+    pub description: Option<String>,
+    pub updated_at: u64,
+}
+
+pub fn save_card(card: &CapabilityCard) {
+    let dir = agora_dir();
+    ensure_dir(&dir);
+    let data = serde_json::to_string_pretty(card).unwrap();
+    let _ = fs::write(dir.join("card.json"), data);
+}
+
+pub fn load_card() -> Option<CapabilityCard> {
+    let path = agora_dir().join("card.json");
+    fs::read_to_string(&path).ok().and_then(|d| serde_json::from_str(&d).ok())
+}
+
+pub fn save_peer_card(room_id: &str, card: &CapabilityCard) {
+    let dir = agora_dir().join("rooms").join(room_id).join("cards");
+    ensure_dir(&dir);
+    let data = serde_json::to_string_pretty(card).unwrap();
+    let _ = fs::write(dir.join(format!("{}.json", card.agent_id)), data);
+}
+
+pub fn load_peer_cards(room_id: &str) -> Vec<CapabilityCard> {
+    let dir = agora_dir().join("rooms").join(room_id).join("cards");
+    if !dir.exists() { return Vec::new(); }
+    let mut cards = Vec::new();
+    if let Ok(entries) = fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            if let Ok(data) = fs::read_to_string(entry.path()) {
+                if let Ok(card) = serde_json::from_str::<CapabilityCard>(&data) {
+                    cards.push(card);
+                }
+            }
+        }
+    }
+    cards
 }
 
 // ── Task Queue ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `agora card "rust,python,kubernetes"` — publish your capabilities
- `agora card-show [agent-id]` — view any agent's card
- `agora discover "python,ML"` — find agents by capability across all rooms

## Design (from plaza discussion)
Cards are signed JSON published as room messages. Peer cards saved locally.
Foundation for trust-weighted discovery, work receipts, and room directory.

## Test plan
- [x] 69 tests pass
- [x] card set + show roundtrip works
- [x] discover searches across rooms

## v0.6 Roadmap
- [x] M1: Capability cards (this PR)
- [ ] M2: Work receipts (Codex)
- [ ] M3: Room directory
- [ ] M4: Trust-weighted discovery (Codex)