### PR TITLE
Fix helper worker ID parsing

### DIFF
--- a/agora-env.sh
+++ b/agora-env.sh
@@ -47,3 +47,26 @@ load_agora_env_defaults() {
         export "$name=$value"
     done < "$env_file"
 }
+
+extract_agora_agent_id() {
+    awk '
+        /^[[:space:]]*Agent ID:/ {
+            sub(/^[[:space:]]*Agent ID:[[:space:]]*/, "", $0)
+            print
+            found = 1
+            exit
+        }
+        /^[[:space:]]*Identity:/ {
+            next
+        }
+        /^[[:space:]]*$/ {
+            next
+        }
+        {
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+            print
+            found = 1
+            exit
+        }
+    '
+}

--- a/wake-codex.sh
+++ b/wake-codex.sh
@@ -110,7 +110,7 @@ resolve_worker_agora_id() {
     agora_bin="$WORKDIR/target/release/agora"
     if [ -x "$agora_bin" ]; then
         local base_id
-        base_id="$("$agora_bin" id 2>/dev/null || true)"
+        base_id="$("$agora_bin" id 2>/dev/null | extract_agora_agent_id || true)"
         if [ -n "$base_id" ]; then
             printf '%s-worker' "$base_id"
             return

--- a/wake-on-agora.sh
+++ b/wake-on-agora.sh
@@ -63,7 +63,7 @@ resolve_worker_agora_id() {
     fi
 
     local base_id
-    base_id="$("$AGORA" id 2>/dev/null || true)"
+    base_id="$("$AGORA" id 2>/dev/null | extract_agora_agent_id || true)"
     if [ -n "$base_id" ]; then
         printf '%s-worker' "$base_id"
         return

--- a/worker-agora.sh
+++ b/worker-agora.sh
@@ -24,7 +24,7 @@ resolve_worker_id() {
     fi
 
     local base_id
-    base_id="$("$AGORA_BIN" id 2>/dev/null || true)"
+    base_id="$("$AGORA_BIN" id 2>/dev/null | extract_agora_agent_id || true)"
     if [ -n "$base_id" ]; then
         printf '%s-worker' "$base_id"
         return


### PR DESCRIPTION
## Summary
- add a shared shell helper to extract the bare agent id from `agora id`
- use that helper in the worker and wake scripts instead of assuming `agora id` returns a raw id
- keep worker aliases stable after the merged identity output changes

## Verification
- `./worker-agora.sh id`
- `./start-plaza-duty.sh`
- `./start-wake-loop.sh`
- `./target/release/agora --room plaza who --online`
- `./target/release/agora --room collab who --online`
