### PR TITLE
Resolve helper scripts via installed agora binary

### DIFF
--- a/agent.sh
+++ b/agent.sh
@@ -8,7 +8,12 @@
 
 set -euo pipefail
 
-AGORA="${AGORA_BIN:-./target/release/agora}"
+WORKDIR="${AGORA_WORKDIR:-$(pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/agora-env.sh"
+load_agora_env_defaults "$WORKDIR"
+
+AGORA="$(require_agora_bin "$WORKDIR")"
 AGENT_ID="${1:-${AGORA_AGENT_ID:-$(${AGORA} id)}}"
 POLL="${2:-30}"
 REPO="${AGORA_REPO:-N3mes1s/agora}"

--- a/agora-env.sh
+++ b/agora-env.sh
@@ -48,6 +48,38 @@ load_agora_env_defaults() {
     done < "$env_file"
 }
 
+resolve_agora_bin() {
+    local workdir="${1:-$(pwd)}"
+
+    if [ -n "${AGORA_BIN:-}" ]; then
+        printf '%s' "$AGORA_BIN"
+        return
+    fi
+
+    if [ -x "$workdir/target/release/agora" ]; then
+        printf '%s' "$workdir/target/release/agora"
+        return
+    fi
+
+    if command -v agora >/dev/null 2>&1; then
+        command -v agora
+        return
+    fi
+
+    printf '%s' "$workdir/target/release/agora"
+}
+
+require_agora_bin() {
+    local workdir="${1:-$(pwd)}"
+    local agora_bin
+    agora_bin="$(resolve_agora_bin "$workdir")"
+    if [ ! -x "$agora_bin" ]; then
+        echo "Agora binary not executable: $agora_bin" >&2
+        return 1
+    fi
+    printf '%s' "$agora_bin"
+}
+
 extract_agora_agent_id() {
     awk '
         /^[[:space:]]*Agent ID:/ {

--- a/sync.sh
+++ b/sync.sh
@@ -6,7 +6,12 @@
 # Example: ./sync.sh 9d107f-cc
 
 set -euo pipefail
-AGORA="./target/release/agora"
+WORKDIR="${AGORA_WORKDIR:-$(pwd)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/agora-env.sh"
+load_agora_env_defaults "$WORKDIR"
+
+AGORA="$(require_agora_bin "$WORKDIR")"
 AGENT_ID="${1:-${AGORA_AGENT_ID:-}}"
 REPO="N3mes1s/agora"
 

--- a/wake-codex.sh
+++ b/wake-codex.sh
@@ -20,6 +20,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/agora-env.sh"
+
 WS_URL="${CODEX_WS_URL:-ws://127.0.0.1:8765}"
 SERVER_SESSION="${CODEX_SERVER_SESSION:-codex_app_server}"
 AGENT_SESSION="${CODEX_AGENT_SESSION:-codex_remote_fork}"
@@ -107,7 +110,7 @@ resolve_worker_agora_id() {
     fi
 
     local agora_bin
-    agora_bin="$WORKDIR/target/release/agora"
+    agora_bin="$(resolve_agora_bin "$WORKDIR")"
     if [ -x "$agora_bin" ]; then
         local base_id
         base_id="$("$agora_bin" id 2>/dev/null | extract_agora_agent_id || true)"

--- a/wake-on-agora.sh
+++ b/wake-on-agora.sh
@@ -19,7 +19,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/agora-env.sh"
 load_agora_env_defaults "$WORKDIR"
 
-AGORA="${AGORA_BIN:-./target/release/agora}"
+AGORA="$(require_agora_bin "$WORKDIR")"
 WAKE_SCRIPT="${WAKE_SCRIPT:-./wake-codex.sh}"
 SOURCE_THREAD="${CODEX_SOURCE_THREAD:-019d5e1a-b68c-70f2-b361-c6ba36537dd1}"
 SINCE="${AGORA_NOTIFY_SINCE:-24h}"
@@ -44,11 +44,6 @@ EOF
 if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
     usage
     exit 0
-fi
-
-if [ ! -x "$AGORA" ]; then
-    echo "Agora binary not executable: $AGORA" >&2
-    exit 1
 fi
 
 if [ ! -x "$WAKE_SCRIPT" ]; then

--- a/worker-agora.sh
+++ b/worker-agora.sh
@@ -8,14 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/agora-env.sh"
 load_agora_env_defaults "$WORKDIR"
 
-AGORA_BIN="${AGORA_BIN:-$WORKDIR/target/release/agora}"
+AGORA_BIN="$(require_agora_bin "$WORKDIR")"
 BASE_HOME="${BASE_HOME:-$HOME}"
 WORKER_HOME="${WORKER_HOME:-$WORKDIR/.worker-home}"
-
-if [ ! -x "$AGORA_BIN" ]; then
-    echo "Agora binary not executable: $AGORA_BIN" >&2
-    exit 1
-fi
 
 resolve_worker_id() {
     if [ -n "${AGORA_WORKER_ID:-}" ]; then


### PR DESCRIPTION
## Summary
- add a shared helper-script resolver for the `agora` binary
- make agent/helper scripts fall back to the installed `agora` on `PATH` when there is no local `./target/release/agora`
- keep `AGORA_BIN` override support intact for explicit deployments

## Why
Fresh cloud workers and release-installed environments now get `agora` from the install path, not from a local Cargo build tree. Several helper scripts still hardcoded `./target/release/agora`, which can make remote workers fail before they ever join rooms.

## Validation
- `bash -n agora-env.sh worker-agora.sh wake-on-agora.sh wake-codex.sh agent.sh sync.sh`
- resolver smoke test: local workdir resolves to `target/release/agora`, `/tmp` resolves to installed `agora` on `PATH`
- `./worker-agora.sh id`

## Notes
This is the cloud-startup half of the current `collab` ask. The separate web-viewer suspicion remains repo config drift: `railway.toml` points at `Dockerfile`, while the public plaza viewer path lives in `Dockerfile.plaza` + `entrypoint-plaza.sh`.