### PR TITLE
Bootstrap the public viewer via env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,11 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/agora /usr/local/bin/agora
+COPY entrypoint-plaza.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENV AGORA_AGENT_ID=plaza-viewer
+ENV AGORA_RELAY_URL=https://ntfy.theagora.dev
+ENV AGORA_BOOTSTRAP_PUBLIC_PLAZA=1
+ENV AGORA_SERVE_READONLY=1
 EXPOSE 8080
-CMD ["agora", "serve", "--port", "8080"]
+CMD ["/entrypoint.sh"]

--- a/Dockerfile.plaza
+++ b/Dockerfile.plaza
@@ -16,5 +16,7 @@ RUN chmod +x /entrypoint.sh
 
 ENV AGORA_AGENT_ID=plaza-viewer
 ENV AGORA_RELAY_URL=https://ntfy.theagora.dev
+ENV AGORA_BOOTSTRAP_PUBLIC_PLAZA=1
+ENV AGORA_SERVE_READONLY=1
 EXPOSE 8080
 CMD ["/entrypoint.sh"]

--- a/entrypoint-plaza.sh
+++ b/entrypoint-plaza.sh
@@ -1,5 +1,29 @@
 #!/bin/sh
-# Join the public plaza room then start the web UI (read-only mode)
-agora join ag-8527472b5ee61dc2 3785b97e52975b8ffdd644852d070881f85be5dec6c6685e34ed6b65ebee4f04 plaza 2>/dev/null || true
-export AGORA_READONLY=1
-exec agora serve --port 8080
+# Bootstrap an optional room, then start the web UI.
+
+set -eu
+
+PLAZA_ROOM_ID="ag-8527472b5ee61dc2"
+PLAZA_ROOM_SECRET="3785b97e52975b8ffdd644852d070881f85be5dec6c6685e34ed6b65ebee4f04"
+PLAZA_ROOM_LABEL="plaza"
+
+PORT="${PORT:-8080}"
+ROOM_ID="${AGORA_BOOTSTRAP_ROOM_ID:-}"
+ROOM_SECRET="${AGORA_BOOTSTRAP_ROOM_SECRET:-}"
+ROOM_LABEL="${AGORA_BOOTSTRAP_ROOM_LABEL:-}"
+
+if [ "${AGORA_BOOTSTRAP_PUBLIC_PLAZA:-0}" = "1" ]; then
+    ROOM_ID="${ROOM_ID:-$PLAZA_ROOM_ID}"
+    ROOM_SECRET="${ROOM_SECRET:-$PLAZA_ROOM_SECRET}"
+    ROOM_LABEL="${ROOM_LABEL:-$PLAZA_ROOM_LABEL}"
+fi
+
+if [ -n "$ROOM_ID" ] && [ -n "$ROOM_SECRET" ] && [ -n "$ROOM_LABEL" ]; then
+    agora join "$ROOM_ID" "$ROOM_SECRET" "$ROOM_LABEL" 2>/dev/null || true
+fi
+
+if [ "${AGORA_SERVE_READONLY:-${AGORA_READONLY:-0}}" = "1" ]; then
+    export AGORA_READONLY=1
+fi
+
+exec agora serve --port "$PORT"

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -313,6 +313,8 @@ fn render_room_page(room_label: &str) -> String {
         .map(|t| format!(r#"<div class="stats">Topic: {}</div>"#, html_escape(t)))
         .unwrap_or_default();
 
+    let readonly = std::env::var("AGORA_READONLY").is_ok();
+
     format!(
         r#"<!DOCTYPE html>
 <html lang="en"><head>
@@ -350,12 +352,14 @@ document.addEventListener('DOMContentLoaded',function(){{document.querySelectorA
   var conn = document.getElementById('conn');
   var messages = document.getElementById('messages');
   var input = document.getElementById('msg-input');
+  var sendForm = document.getElementById('sf');
   var replyField = document.getElementById('reply-to-field');
   var replyBanner = document.getElementById('reply-banner');
   var replyLabel = document.getElementById('reply-label');
 
   // ── Reply ──────────────────────────────────────────────────────
   window.setReply = function(msgId, sender) {{
+    if (!replyField || !replyLabel || !replyBanner || !input) return;
     replyField.value = msgId;
     replyLabel.textContent = '↩ replying to ' + sender + ' [' + msgId + ']';
     replyBanner.classList.add('active');
@@ -363,6 +367,7 @@ document.addEventListener('DOMContentLoaded',function(){{document.querySelectorA
   }};
 
   window.cancelReply = function() {{
+    if (!replyField || !replyBanner) return;
     replyField.value = '';
     replyBanner.classList.remove('active');
   }};
@@ -424,22 +429,24 @@ document.addEventListener('DOMContentLoaded',function(){{document.querySelectorA
   }};
 
   // ── Send form (fetch, no reload) ───────────────────────────────
-  document.getElementById('sf').addEventListener('submit', function(e) {{
-    e.preventDefault();
-    var text = input.value.trim();
-    if (!text) return;
-    var body = 'message=' + encodeURIComponent(text);
-    if (replyField.value) {{
-      body += '&reply_to=' + encodeURIComponent(replyField.value);
-    }}
-    fetch('/{label}/send', {{
-      method: 'POST',
-      headers: {{'Content-Type': 'application/x-www-form-urlencoded'}},
-      body: body
-    }}).catch(function() {{}});
-    input.value = '';
-    cancelReply();
-  }});
+  if (sendForm && input) {{
+    sendForm.addEventListener('submit', function(e) {{
+      e.preventDefault();
+      var text = input.value.trim();
+      if (!text) return;
+      var body = 'message=' + encodeURIComponent(text);
+      if (replyField && replyField.value) {{
+        body += '&reply_to=' + encodeURIComponent(replyField.value);
+      }}
+      fetch('/{label}/send', {{
+        method: 'POST',
+        headers: {{'Content-Type': 'application/x-www-form-urlencoded'}},
+        body: body
+      }}).catch(function() {{}});
+      input.value = '';
+      cancelReply();
+    }});
+  }}
 
   // ── SSE live tail ───────────────────────────────────────────────
   function connectSSE() {{
@@ -493,7 +500,7 @@ document.addEventListener('DOMContentLoaded',function(){{document.querySelectorA
         topic_line = topic_line,
         rows = rows,
         last_ts = last_ts,
-        send_form = if std::env::var("AGORA_READONLY").is_ok() {
+        send_form = if readonly {
             format!(r#"<div style="position:sticky;bottom:0;background:#0a0a0f;border-top:1px solid #1e1e2e;padding:20px 0;text-align:center">
               <p style="color:#8888a0;margin-bottom:12px">You are watching a live conversation between AI agents.</p>
               <a href="https://theagora.dev#install" style="background:linear-gradient(135deg,#6c5ce7,#00cec9);color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600">Install agora and join</a>
@@ -1156,6 +1163,43 @@ mod tests {
         assert!(html.contains("/collab"));
         assert!(html.contains("thread-item root"));
         assert!(html.contains("roomLabel = \"collab\""));
+    }
+
+    #[test]
+    fn test_render_room_page_readonly_guards_missing_form() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let home = std::env::temp_dir().join(format!(
+            "agora-serve-readonly-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("AGORA_AGENT_ID", "serve-test");
+            std::env::set_var("AGORA_READONLY", "1");
+        }
+
+        let room = store::add_room("ag-readonly-test", "secret", "plaza", store::Role::Admin);
+        store::save_message(&room.room_id, &serde_json::json!({
+            "id": "root1234",
+            "from": "alice",
+            "ts": std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            "text": "hello",
+            "v": "4.0",
+        }));
+
+        let html = render_room_page("plaza");
+        assert!(html.contains("Install agora and join"));
+        assert!(!html.contains("<form id=\"sf\""));
+        assert!(html.contains("var sendForm = document.getElementById('sf');"));
+        assert!(html.contains("if (sendForm && input) {"));
+        assert!(!html.contains("document.getElementById('sf').addEventListener"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make the main app container capable of bootstrapping the public viewer through env
- keep the dedicated plaza viewer image aligned with the same entrypoint/env behavior
- generalize `entrypoint-plaza.sh` into an env-driven bootstrap wrapper

## Why
The repo currently has two diverging deploy paths:
- `Dockerfile` starts `agora serve` directly
- `Dockerfile.plaza` joins `plaza` and sets read-only mode first

That makes the public viewer depend on Railway selecting the right Dockerfile. This patch lets the main app image bootstrap the public `plaza` viewer with env (`AGORA_BOOTSTRAP_PUBLIC_PLAZA=1`, `AGORA_SERVE_READONLY=1`) so the repo-side deploy path is less fragile.

## Validation
- `sh -n entrypoint-plaza.sh`

## Notes
This is a repo-side mitigation for the stale public viewer path. It does not replace Railway-side service/domain config.