### PR TITLE
serve: preserve auth JSON status codes

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -732,9 +732,18 @@ fn render_404(label: &str) -> String {
 
 // ── HTTP primitives ──────────────────────────────────────────────
 
+fn json_status(code: u16) -> &'static str {
+    match code {
+        200 => "200 OK",
+        400 => "400 Bad Request",
+        401 => "401 Unauthorized",
+        404 => "404 Not Found",
+        _ => "500 Internal Server Error",
+    }
+}
+
 fn send_json(stream: TcpStream, code: u16, body: &str) {
-    let status = match code { 200 => "200 OK", 400 => "400 Bad Request", _ => "500 Internal Server Error" };
-    send_response(stream, status, "application/json", body);
+    send_response(stream, json_status(code), "application/json", body);
 }
 
 fn send_response(mut stream: TcpStream, status: &str, content_type: &str, body: &str) {
@@ -1287,5 +1296,12 @@ mod tests {
         let body = "message_id=abc123&emoji=%F0%9F%94%A5";
         assert_eq!(form_field(body, "message_id"), Some("abc123".to_string()));
         assert!(form_field(body, "emoji").is_some());
+    }
+
+    #[test]
+    fn test_json_status_preserves_401_status() {
+        assert_eq!(json_status(401), "401 Unauthorized");
+        assert_eq!(json_status(404), "404 Not Found");
+        assert_eq!(json_status(500), "500 Internal Server Error");
     }
 }


### PR DESCRIPTION
## Summary
- preserve JSON `401 Unauthorized` and `404 Not Found` instead of collapsing every non-200/400 response to `500`
- add a focused regression test for the status mapping helper

## Why
The live sandbox probe showed `POST /api/sandbox/create` returning `500 {"error":"Malformed token"}` for an auth failure. The route logic was already sending `401`, but `send_json()` only knew `200` and `400`, so it rewrote all other codes to `500 Internal Server Error`.

## Validation
- `cargo test test_json_status_preserves_401_status -- --nocapture`
- `cargo build --release`
- raw live probe before fix showed `HTTP/2 500` with body `{"error":"Malformed token"}` on the sandbox create endpoint
