### PR TITLE
roles: add room-scoped specialist leases

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -136,6 +136,10 @@ fn is_work_receipt(env: &serde_json::Value) -> bool {
     env["type"].as_str() == Some("work_receipt")
 }
 
+fn is_role_state(env: &serde_json::Value) -> bool {
+    env["type"].as_str() == Some("role_state")
+}
+
 fn make_reaction(target_id: &str, emoji: &str) -> serde_json::Value {
     json!({
         "v": VERSION,
@@ -220,6 +224,7 @@ fn is_system_msg(env: &serde_json::Value) -> bool {
     is_heartbeat(env)
         || is_receipt(env)
         || is_work_receipt(env)
+        || is_role_state(env)
         || is_file_msg(env)
         || is_reaction(env)
         || is_invite_redeem(env)
@@ -404,6 +409,38 @@ fn ingest_auxiliary_event(room_id: &str, env: &serde_json::Value) {
         return;
     }
 
+    if is_role_state(env) {
+        let role = env["role_name"].as_str().unwrap_or("").trim().to_string();
+        if role.is_empty() {
+            return;
+        }
+        if env["role_action"].as_str() == Some("release") {
+            store::remove_role_lease(room_id, &role);
+            return;
+        }
+        let lease = store::RoleLease {
+            role,
+            agent_id: from.to_string(),
+            lease_expires: env["lease_expires"].as_u64().unwrap_or(0),
+            last_heartbeat: env["last_heartbeat"]
+                .as_u64()
+                .unwrap_or_else(|| env["ts"].as_u64().unwrap_or(0)),
+            context_summary: env["context_summary"].as_str().map(|s| s.to_string()),
+            last_task_ids: env["last_task_ids"]
+                .as_array()
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| item.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            updated_at: env["ts"].as_u64().unwrap_or(0),
+        };
+        store::upsert_role_lease(room_id, &lease);
+        return;
+    }
+
     if is_capability_card(env) {
         let capabilities = env["card_capabilities"]
             .as_array()
@@ -434,6 +471,7 @@ fn should_display_message(env: &serde_json::Value) -> bool {
         && !is_invite_redeem(env)
         && !is_receipt(env)
         && !is_work_receipt(env)
+        && !is_role_state(env)
         && !is_reaction(env)
         && !is_capability_card(env)
 }
@@ -992,6 +1030,148 @@ pub fn set_profile(name: Option<&str>, role: Option<&str>, room_label: Option<&s
 pub fn whois(agent_id: &str, room_label: Option<&str>) -> Result<Option<store::AgentProfile>, String> {
     let room = resolve_room(room_label)?;
     Ok(store::get_profile(&room.room_id, agent_id))
+}
+
+fn claimed_task_ids(room_id: &str, agent_id: &str) -> Vec<String> {
+    store::load_tasks(room_id)
+        .into_iter()
+        .filter(|task| task.status != "done" && task.claimed_by.as_deref() == Some(agent_id))
+        .map(|task| task.id)
+        .collect()
+}
+
+fn publish_role_state(
+    room: &store::RoomEntry,
+    lease: &store::RoleLease,
+    action: &str,
+) -> Result<(), String> {
+    let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
+    let text = match action {
+        "claim" => format!("[role] {} claimed {}", lease.agent_id, lease.role),
+        "release" => format!("[role] {} released {}", lease.agent_id, lease.role),
+        _ => format!("[role] {} heartbeat {}", lease.agent_id, lease.role),
+    };
+    let env = json!({
+        "v": VERSION,
+        "id": msg_id(),
+        "from": lease.agent_id,
+        "ts": now(),
+        "type": "role_state",
+        "role_name": lease.role,
+        "role_action": action,
+        "lease_expires": lease.lease_expires,
+        "last_heartbeat": lease.last_heartbeat,
+        "context_summary": lease.context_summary,
+        "last_task_ids": lease.last_task_ids,
+        "text": text,
+    });
+    let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
+    transport::publish(&room.room_id, &encrypted);
+    store::save_message(&room.room_id, &env);
+    Ok(())
+}
+
+pub fn role_claim(
+    role: &str,
+    summary: Option<&str>,
+    ttl_secs: u64,
+    room_label: Option<&str>,
+) -> Result<store::RoleLease, String> {
+    let room = resolve_room(room_label)?;
+    let me = store::get_agent_id();
+    let now_ts = now();
+
+    if let Some(existing) = store::get_role_lease(&room.room_id, role) {
+        if existing.agent_id != me && existing.lease_expires > now_ts {
+            return Err(format!(
+                "Role '{}' is currently held by '{}' for another {}s.",
+                role,
+                existing.agent_id,
+                existing.lease_expires.saturating_sub(now_ts)
+            ));
+        }
+    }
+
+    let lease = store::RoleLease {
+        role: role.to_string(),
+        agent_id: me.clone(),
+        lease_expires: now_ts + ttl_secs,
+        last_heartbeat: now_ts,
+        context_summary: summary.map(|s| s.to_string()),
+        last_task_ids: claimed_task_ids(&room.room_id, &me),
+        updated_at: now_ts,
+    };
+    store::upsert_role_lease(&room.room_id, &lease);
+    publish_role_state(&room, &lease, "claim")?;
+    Ok(lease)
+}
+
+pub fn role_heartbeat(
+    role: &str,
+    summary: Option<&str>,
+    ttl_secs: u64,
+    room_label: Option<&str>,
+) -> Result<store::RoleLease, String> {
+    let room = resolve_room(room_label)?;
+    let me = store::get_agent_id();
+    let now_ts = now();
+    let existing = store::get_role_lease(&room.room_id, role);
+
+    if let Some(current) = &existing {
+        if current.agent_id != me && current.lease_expires > now_ts {
+            return Err(format!(
+                "Role '{}' is currently held by '{}' for another {}s.",
+                role,
+                current.agent_id,
+                current.lease_expires.saturating_sub(now_ts)
+            ));
+        }
+    }
+
+    let lease = store::RoleLease {
+        role: role.to_string(),
+        agent_id: me.clone(),
+        lease_expires: now_ts + ttl_secs,
+        last_heartbeat: now_ts,
+        context_summary: summary
+            .map(|s| s.to_string())
+            .or_else(|| existing.and_then(|current| current.context_summary)),
+        last_task_ids: claimed_task_ids(&room.room_id, &me),
+        updated_at: now_ts,
+    };
+    store::upsert_role_lease(&room.room_id, &lease);
+    publish_role_state(&room, &lease, "heartbeat")?;
+    Ok(lease)
+}
+
+pub fn role_release(role: &str, room_label: Option<&str>) -> Result<(), String> {
+    let room = resolve_room(room_label)?;
+    let me = store::get_agent_id();
+    let now_ts = now();
+    let existing = store::get_role_lease(&room.room_id, role)
+        .ok_or_else(|| format!("Role '{}' is not currently claimed.", role))?;
+
+    if existing.agent_id != me && existing.lease_expires > now_ts {
+        return Err(format!("Role '{}' is currently held by '{}'.", role, existing.agent_id));
+    }
+
+    let released = store::RoleLease {
+        role: existing.role.clone(),
+        agent_id: me,
+        lease_expires: now_ts,
+        last_heartbeat: now_ts,
+        context_summary: existing.context_summary.clone(),
+        last_task_ids: existing.last_task_ids.clone(),
+        updated_at: now_ts,
+    };
+    store::remove_role_lease(&room.room_id, role);
+    publish_role_state(&room, &released, "release")?;
+    Ok(())
+}
+
+pub fn list_role_leases(room_label: Option<&str>) -> Result<Vec<store::RoleLease>, String> {
+    let room = resolve_room(room_label)?;
+    Ok(store::load_role_leases(&room.room_id))
 }
 
 // ── Room Directory ─────────────────────────────────────────────
@@ -3523,10 +3703,11 @@ mod tests {
         allow_incoming_message, annotate_soma_message, count_invite_redemptions_in_envs,
         decrypt_payload, discover, discovery_decay_weight, enforce_outbound_plaza_rate_limit,
         encrypt_envelope,
-        infer_soma_subject_path, ingest_auxiliary_event, list_work_receipts, make_envelope,
-        make_invite_redemption, pin, pins, resolve_room, seed_plaza_rate_limit_state,
-        send_watch_heartbeat, should_display_message, signing_message_bytes, soma_churn_decay,
-        soma_correct, stale_claim_weight, task_add, task_checkpoint, task_done, unpin,
+        infer_soma_subject_path, ingest_auxiliary_event, list_role_leases, list_work_receipts,
+        make_envelope, make_invite_redemption, pin, pins, resolve_room, role_claim,
+        role_heartbeat, role_release, seed_plaza_rate_limit_state, send_watch_heartbeat,
+        should_display_message, signing_message_bytes, soma_churn_decay, soma_correct,
+        stale_claim_weight, task_add, task_checkpoint, task_done, unpin,
         SignedWirePayload, SIGNED_WIRE_VERSION, BASE64, DISCOVERY_POSITIVE_HALF_LIFE_SECS,
         PLAZA_RATE_LIMIT_WINDOW_SECS,
     };
@@ -3828,6 +4009,58 @@ mod tests {
         assert_eq!(receipts[0].receipt.status, "checkpoint");
         assert_eq!(receipts[0].receipt.witness_ids.len(), 2);
         assert_eq!(receipts[0].receipt.auth, "verified");
+    }
+
+    #[test]
+    fn role_state_messages_are_hidden_but_cached() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let (_home, room) = setup_plaza_room("role-reader", Role::Admin);
+        let now_ts = current_ts();
+        let env = json!({
+            "id": "role1",
+            "from": "backend-peer",
+            "ts": now_ts,
+            "type": "role_state",
+            "role_name": "backend",
+            "role_action": "claim",
+            "lease_expires": now_ts + 900,
+            "last_heartbeat": now_ts,
+            "context_summary": "Owns transport",
+            "last_task_ids": ["task123"],
+            "text": "[role] backend-peer claimed backend",
+        });
+
+        assert!(!should_display_message(&env));
+        ingest_auxiliary_event(&room.room_id, &env);
+
+        let lease = store::get_role_lease(&room.room_id, "backend").unwrap();
+        assert_eq!(lease.agent_id, "backend-peer");
+        assert_eq!(lease.context_summary.as_deref(), Some("Owns transport"));
+        assert_eq!(lease.last_task_ids, vec!["task123".to_string()]);
+    }
+
+    #[test]
+    fn role_claim_heartbeat_and_release_manage_leases() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let (_home, room) = setup_plaza_room("backend-agent", Role::Admin);
+
+        let claimed = role_claim("backend", Some("Owns chat/store"), 900, Some("plaza")).unwrap();
+        assert_eq!(claimed.role, "backend");
+        assert_eq!(claimed.agent_id, "backend-agent");
+        assert_eq!(claimed.context_summary.as_deref(), Some("Owns chat/store"));
+
+        let leases = list_role_leases(Some("plaza")).unwrap();
+        assert_eq!(leases.len(), 1);
+        assert_eq!(leases[0].role, "backend");
+
+        let heartbeat =
+            role_heartbeat("backend", Some("Owns transport too"), 1200, Some("plaza")).unwrap();
+        assert!(heartbeat.lease_expires >= claimed.lease_expires);
+        let stored = store::get_role_lease(&room.room_id, "backend").unwrap();
+        assert_eq!(stored.context_summary.as_deref(), Some("Owns transport too"));
+
+        role_release("backend", Some("plaza")).unwrap();
+        assert!(store::get_role_lease(&room.room_id, "backend").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -450,37 +450,6 @@ enum Commands {
         agent_id: String,
     },
 
-    /// Claim a persistent specialist role (e.g. "backend", "security")
-    RoleClaim {
-        /// Role name
-        role: String,
-        /// Lease duration in seconds (default: 3600)
-        #[arg(long, default_value = "3600")]
-        ttl: u64,
-    },
-
-    /// Send a heartbeat for a held role (extends lease, saves context)
-    RoleHeartbeat {
-        /// Role name
-        role: String,
-        /// Context summary — what you are working on
-        context: Vec<String>,
-        /// Lease extension in seconds (default: 3600)
-        #[arg(long, default_value = "3600")]
-        ttl: u64,
-    },
-
-    /// Release a role lease (stores final context for the next holder)
-    RoleRelease {
-        /// Role name
-        role: String,
-        /// Final context summary
-        context: Vec<String>,
-    },
-
-    /// Show active role leases and last context summaries
-    Roles,
-
     /// Vouch for another agent (adds to their trust score)
     Vouch {
         /// Agent ID to vouch for
@@ -573,6 +542,39 @@ enum Commands {
 
     /// List tasks in the room
     Tasks,
+
+    /// Claim a persistent specialist role in the room
+    RoleClaim {
+        /// Role name (e.g. backend, security)
+        role: String,
+        /// Optional context summary
+        #[arg(long)]
+        summary: Option<String>,
+        /// Lease duration in seconds
+        #[arg(long, default_value = "900")]
+        ttl: u64,
+    },
+
+    /// Refresh a claimed specialist role lease
+    RoleHeartbeat {
+        /// Role name (e.g. backend, security)
+        role: String,
+        /// Optional context summary override
+        #[arg(long)]
+        summary: Option<String>,
+        /// Lease duration in seconds
+        #[arg(long, default_value = "900")]
+        ttl: u64,
+    },
+
+    /// Release a claimed specialist role
+    RoleRelease {
+        /// Role name (e.g. backend, security)
+        role: String,
+    },
+
+    /// List cached specialist role leases
+    Roles,
 
     /// Show cached work receipts
     Receipts {
@@ -1064,7 +1066,7 @@ fn print_soma_details(belief: &serde_json::Value) {
 
 fn print_msg_with_depth(env: &serde_json::Value, depth: usize) {
     match env["type"].as_str() {
-        Some("heartbeat" | "receipt" | "reaction" | "invite_redeem" | "work_receipt") => return,
+        Some("heartbeat" | "receipt" | "reaction" | "invite_redeem" | "work_receipt" | "role_state") => return,
         _ => {}
     }
     let time = ts(env["ts"].as_u64().unwrap_or(0));
@@ -2337,56 +2339,6 @@ fn main() {
             }
         }
 
-        Commands::RoleClaim { role, ttl } => {
-            let me = store::get_agent_id();
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-            match store::role_claim(&role, &me, ttl, ts) {
-                Ok(()) => println!("  Role '{role}' claimed by {me} for {ttl}s."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::RoleHeartbeat { role, context, ttl } => {
-            let me = store::get_agent_id();
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-            let ctx = context.join(" ");
-            match store::role_heartbeat(&role, &me, ttl, &ctx, ts) {
-                Ok(()) => println!("  Heartbeat sent for role '{role}'. Context saved."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::RoleRelease { role, context } => {
-            let me = store::get_agent_id();
-            let ctx = context.join(" ");
-            match store::role_release(&role, &me, &ctx) {
-                Ok(()) => println!("  Role '{role}' released. Context stored for next holder."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Roles => {
-            let ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-            let leases = store::load_role_leases();
-            if leases.is_empty() {
-                println!("  No role leases on file.");
-            } else {
-                for l in &leases {
-                    let status = if l.expires_at > ts {
-                        format!("ACTIVE ({}s remaining)", l.expires_at - ts)
-                    } else {
-                        "EXPIRED".to_string()
-                    };
-                    println!("  {:12} {:20} {}  context: {}",
-                        l.role, l.agent_id, status,
-                        if l.context_summary.is_empty() { "(none)" } else { &l.context_summary });
-                }
-            }
-        }
-
         Commands::Bounties => {
             match chat::bounty_list(room) {
                 Ok(bounties) => {
@@ -2657,6 +2609,80 @@ fn main() {
                         for t in &done {
                             let note = t.notes.as_deref().unwrap_or("");
                             println!("    [{}] {} {}", &t.id[..6.min(t.id.len())], t.title, if note.is_empty() { String::new() } else { format!("— {note}") });
+                        }
+                    }
+                }
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+            }
+        }
+
+        Commands::RoleClaim { role, summary, ttl } => {
+            match chat::role_claim(&role, summary.as_deref(), ttl, room) {
+                Ok(lease) => {
+                    println!(
+                        "  Claimed role '{}' until {} ({}s).",
+                        lease.role,
+                        ts(lease.lease_expires),
+                        lease.lease_expires.saturating_sub(lease.last_heartbeat)
+                    );
+                    if let Some(summary) = lease.context_summary {
+                        println!("  Context: {summary}");
+                    }
+                }
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+            }
+        }
+
+        Commands::RoleHeartbeat { role, summary, ttl } => {
+            match chat::role_heartbeat(&role, summary.as_deref(), ttl, room) {
+                Ok(lease) => {
+                    println!(
+                        "  Refreshed role '{}' until {} ({}s).",
+                        lease.role,
+                        ts(lease.lease_expires),
+                        lease.lease_expires.saturating_sub(lease.last_heartbeat)
+                    );
+                    if let Some(summary) = lease.context_summary {
+                        println!("  Context: {summary}");
+                    }
+                }
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+            }
+        }
+
+        Commands::RoleRelease { role } => {
+            match chat::role_release(&role, room) {
+                Ok(()) => println!("  Released role '{}'.", role),
+                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+            }
+        }
+
+        Commands::Roles => {
+            match chat::list_role_leases(room) {
+                Ok(leases) => {
+                    if leases.is_empty() {
+                        println!("  (no role leases)");
+                        return;
+                    }
+                    let now_ts = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs();
+                    for lease in leases {
+                        let holder = resolve_display_name(&lease.agent_id);
+                        let state = if lease.lease_expires > now_ts { "active" } else { "expired" };
+                        println!(
+                            "  {} — {} [{}] until {}",
+                            lease.role,
+                            holder,
+                            state,
+                            ts(lease.lease_expires)
+                        );
+                        if let Some(summary) = lease.context_summary {
+                            println!("    {summary}");
+                        }
+                        if !lease.last_task_ids.is_empty() {
+                            println!("    tasks: {}", lease.last_task_ids.join(", "));
                         }
                     }
                 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -937,93 +937,6 @@ pub fn find_payment_by_stripe_id(stripe_id: &str) -> Option<PaymentRecord> {
     load_payments().into_iter().find(|p| p.stripe_id.as_deref() == Some(stripe_id))
 }
 
-// ── Role Leases ────────────────────────────────────────────────
-
-/// A persistent specialist role lease. Agents claim a role for a TTL; the role is
-/// released on shutdown or expires automatically so another agent can claim it.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct RoleLease {
-    pub role: String,
-    pub agent_id: String,
-    pub expires_at: u64,
-    pub last_heartbeat: u64,
-    pub context_summary: String,
-}
-
-fn role_leases_path() -> std::path::PathBuf {
-    agora_dir().join("role_leases.json")
-}
-
-pub fn load_role_leases() -> Vec<RoleLease> {
-    let path = role_leases_path();
-    if let Ok(data) = fs::read_to_string(&path) {
-        serde_json::from_str(&data).unwrap_or_default()
-    } else {
-        Vec::new()
-    }
-}
-
-pub fn save_role_leases(leases: &[RoleLease]) {
-    let data = serde_json::to_string_pretty(leases).unwrap();
-    let _ = fs::write(role_leases_path(), data);
-}
-
-/// Claim a role for `ttl_secs`. Returns Err if a non-expired lease already exists.
-pub fn role_claim(role: &str, agent_id: &str, ttl_secs: u64, now_ts: u64) -> Result<(), String> {
-    let mut leases = load_role_leases();
-    // Remove expired leases for this role
-    leases.retain(|l| l.role != role || l.expires_at > now_ts);
-    if leases.iter().any(|l| l.role == role) {
-        let holder = leases.iter().find(|l| l.role == role).unwrap();
-        return Err(format!("Role '{}' held by {} until {}", role, holder.agent_id, holder.expires_at));
-    }
-    leases.push(RoleLease {
-        role: role.to_string(),
-        agent_id: agent_id.to_string(),
-        expires_at: now_ts + ttl_secs,
-        last_heartbeat: now_ts,
-        context_summary: String::new(),
-    });
-    save_role_leases(&leases);
-    Ok(())
-}
-
-/// Extend a role lease and update context summary.
-pub fn role_heartbeat(role: &str, agent_id: &str, ttl_secs: u64, context: &str, now_ts: u64) -> Result<(), String> {
-    let mut leases = load_role_leases();
-    let lease = leases.iter_mut()
-        .find(|l| l.role == role && l.agent_id == agent_id)
-        .ok_or_else(|| format!("No active lease for role '{}' by agent '{}'", role, agent_id))?;
-    lease.expires_at = now_ts + ttl_secs;
-    lease.last_heartbeat = now_ts;
-    lease.context_summary = context.to_string();
-    save_role_leases(&leases);
-    Ok(())
-}
-
-/// Release a role lease and store final context summary.
-pub fn role_release(role: &str, agent_id: &str, context: &str) -> Result<(), String> {
-    let mut leases = load_role_leases();
-    let pos = leases.iter().position(|l| l.role == role && l.agent_id == agent_id)
-        .ok_or_else(|| format!("No active lease for role '{}' by agent '{}'", role, agent_id))?;
-    let mut lease = leases.remove(pos);
-    // Keep as expired tombstone so next agent can read context_summary
-    lease.expires_at = 0;
-    lease.context_summary = context.to_string();
-    leases.push(lease);
-    save_role_leases(&leases);
-    Ok(())
-}
-
-/// Get context summary from the last agent who held a role (even if expired).
-pub fn role_last_context(role: &str) -> Option<String> {
-    let leases = load_role_leases();
-    leases.iter()
-        .filter(|l| l.role == role)
-        .max_by_key(|l| l.last_heartbeat)
-        .map(|l| l.context_summary.clone())
-}
-
 // ── Calibration Seeds ──────────────────────────────────────────
 
 /// A calibration seed: a self-verifiable puzzle for trust bootstrapping.
@@ -1129,11 +1042,11 @@ pub enum LeaseStatus {
 /// Persisted so crash recovery can detect and close stale leases.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxLease {
-    pub id: String,           // matches SandboxSession.id
+    pub id: String, // matches SandboxSession.id
     pub agent_id: String,
     pub max_cost_credits: i64,
     pub credits_per_minute: i64,
-    pub started_at: u64,      // unix timestamp
+    pub started_at: u64, // unix timestamp
     pub status: LeaseStatus,
     #[serde(default)]
     pub actual_cost: Option<i64>, // set when closed
@@ -1160,7 +1073,10 @@ pub fn save_leases(room_id: &str, leases: &[SandboxLease]) {
 /// Open a new lease. Returns Err if the agent already has an active lease in this room.
 pub fn open_lease(room_id: &str, lease: SandboxLease) -> Result<(), String> {
     let mut leases = load_leases(room_id);
-    if leases.iter().any(|l| l.agent_id == lease.agent_id && l.status == LeaseStatus::Active) {
+    if leases
+        .iter()
+        .any(|l| l.agent_id == lease.agent_id && l.status == LeaseStatus::Active)
+    {
         return Err(format!("Agent {} already has an active lease", lease.agent_id));
     }
     leases.push(lease);
@@ -1198,6 +1114,63 @@ pub fn recover_stale_leases(room_id: &str) -> Vec<SandboxLease> {
         save_leases(room_id, &leases);
     }
     recovered
+}
+
+// ── Role Leases ────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleLease {
+    pub role: String,
+    pub agent_id: String,
+    pub lease_expires: u64,
+    pub last_heartbeat: u64,
+    #[serde(default)]
+    pub context_summary: Option<String>,
+    #[serde(default)]
+    pub last_task_ids: Vec<String>,
+    pub updated_at: u64,
+}
+
+pub fn load_role_leases(room_id: &str) -> Vec<RoleLease> {
+    let path = agora_dir().join("rooms").join(room_id).join("role_leases.json");
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
+pub fn save_role_leases(room_id: &str, roles: &[RoleLease]) {
+    let dir = agora_dir().join("rooms").join(room_id);
+    ensure_dir(&dir);
+    let data = serde_json::to_string_pretty(roles).unwrap();
+    let _ = fs::write(dir.join("role_leases.json"), data);
+}
+
+pub fn upsert_role_lease(room_id: &str, lease: &RoleLease) {
+    let mut roles = load_role_leases(room_id);
+    if let Some(existing) = roles.iter_mut().find(|r| r.role == lease.role) {
+        *existing = lease.clone();
+    } else {
+        roles.push(lease.clone());
+    }
+    roles.sort_by(|a, b| a.role.cmp(&b.role));
+    save_role_leases(room_id, &roles);
+}
+
+pub fn remove_role_lease(room_id: &str, role: &str) {
+    let mut roles = load_role_leases(room_id);
+    let before = roles.len();
+    roles.retain(|r| r.role != role);
+    if roles.len() != before {
+        save_role_leases(room_id, &roles);
+    }
+}
+
+pub fn get_role_lease(room_id: &str, role: &str) -> Option<RoleLease> {
+    load_role_leases(room_id)
+        .into_iter()
+        .find(|lease| lease.role == role)
 }
 
 // ── Aliases ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add room-scoped specialist role leases cached in `role_leases.json`
- publish and ingest hidden `role_state` events for claim, heartbeat, and release
- add CLI commands: `role-claim`, `role-heartbeat`, `role-release`, and `roles`

## Design
This is the minimal backend slice discussed in `collab`:
- reuse existing room/task/receipt/event machinery
- no separate scheduler database yet
- derive `last_task_ids` from currently claimed tasks instead of maintaining a second queue

## Validation
- `cargo test role_state_ -- --nocapture`
- `cargo test role_claim_heartbeat_and_release_manage_leases -- --nocapture`
- `cargo test test_json_status_preserves_401_status -- --nocapture`
- `cargo build --release`

## Stack
This PR is stacked on top of #90 so the auth-status fix can merge first.
