### PR TITLE
Require bearer auth for tasks API writes

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -101,6 +101,20 @@ fn make_envelope(text: &str, reply_to: Option<&str>) -> serde_json::Value {
     env
 }
 
+fn make_envelope_from(sender: &str, text: &str, reply_to: Option<&str>) -> serde_json::Value {
+    let mut env = json!({
+        "v": VERSION,
+        "id": msg_id(),
+        "from": sender,
+        "ts": now(),
+        "text": text,
+    });
+    if let Some(rt) = reply_to {
+        env["reply_to"] = json!(rt);
+    }
+    env
+}
+
 fn make_heartbeat() -> serde_json::Value {
     json!({
         "v": VERSION,
@@ -2778,14 +2792,19 @@ fn publish_task_receipt(
 
 /// Add a task to the room queue.
 pub fn task_add(title: &str, room_label: Option<&str>) -> Result<String, String> {
+    let me = store::get_agent_id();
+    task_add_as(&me, title, room_label)
+}
+
+/// Add a task to the room queue on behalf of a verified agent.
+pub fn task_add_as(agent_id: &str, title: &str, room_label: Option<&str>) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let id = msg_id();
-    let me = store::get_agent_id();
     let task = store::Task {
         id: id.clone(),
         title: title.to_string(),
         status: "open".to_string(),
-        created_by: me.clone(),
+        created_by: agent_id.to_string(),
         claimed_by: None,
         created_at: now(),
         updated_at: now(),
@@ -2800,7 +2819,7 @@ pub fn task_add(title: &str, room_label: Option<&str>) -> Result<String, String>
     store::save_tasks(&room.room_id, &tasks);
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("[task] New: {title} (id: {})", &id[..6]), None);
+    let env = make_envelope_from(agent_id, &format!("[task] New: {title} (id: {})", &id[..6]), None);
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
@@ -4117,7 +4136,7 @@ mod tests {
         role_heartbeat, role_release, payment_complete_solana_deposit,
         seed_plaza_rate_limit_state, send_watch_heartbeat,
         should_display_message, signing_message_bytes, soma_churn_decay, soma_correct,
-        bounty_submit, bounty_verify, stale_claim_weight, task_add, task_add_with_oracle,
+        bounty_submit, bounty_verify, stale_claim_weight, task_add, task_add_as, task_add_with_oracle,
         task_checkpoint, task_done, unpin,
         verified_solana_deposit_from_tx, SignedWirePayload, VerifiedSolanaDeposit,
         SIGNED_WIRE_VERSION, BASE64, DISCOVERY_POSITIVE_HALF_LIFE_SECS,
@@ -5025,6 +5044,26 @@ mod tests {
             let b = window[1]["credits"].as_i64().unwrap_or(0);
             assert!(a >= b, "leaderboard must be sorted by credits descending");
         }
+    }
+
+    #[test]
+    fn task_add_as_records_verified_creator() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let (_home, room) = setup_plaza_room("server-host", Role::Admin);
+
+        let task_id = task_add_as("api-agent", "Ship API auth", Some("plaza")).unwrap();
+
+        let tasks = store::load_tasks(&room.room_id);
+        let task = tasks.iter().find(|t| t.id == task_id).expect("task saved");
+        assert_eq!(task.created_by, "api-agent");
+
+        let messages = store::load_messages(&room.room_id, 3600);
+        let msg = messages
+            .iter()
+            .find(|m| m["id"].as_str() == Some(task_id.as_str()))
+            .or_else(|| messages.iter().find(|m| m["text"].as_str().unwrap_or("").contains("Ship API auth")))
+            .expect("task message saved");
+        assert_eq!(msg["from"].as_str(), Some("api-agent"));
     }
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -847,6 +847,19 @@ fn get_header<'a>(raw: &'a str, name: &str) -> Option<&'a str> {
     None
 }
 
+fn bearer_token(raw: &str) -> Option<&str> {
+    get_header(raw, "Authorization")
+        .and_then(|h| h.strip_prefix("Bearer ").or_else(|| h.strip_prefix("bearer ")))
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+}
+
+fn verify_bearer_agent_token(raw: &str) -> Result<String, String> {
+    let token = bearer_token(raw).ok_or_else(|| "missing bearer token".to_string())?;
+    let (agent_id, _expiry) = sandbox::verify_agent_token(token)?;
+    Ok(agent_id)
+}
+
 /// Verify a Stripe webhook signature.
 ///
 /// Stripe-Signature header format: `t=<timestamp>,v1=<hmac_hex>`
@@ -1278,6 +1291,13 @@ fn handle_connection(stream: TcpStream) {
         // JSON body: {"title": "...", "room": "..."}
         // Returns: {"id": "<task-id>", "title": "..."}
         ("POST", ["api", "v1", "tasks"]) => {
+            let agent_id = match verify_bearer_agent_token(&raw) {
+                Ok(agent_id) => agent_id,
+                Err(e) => {
+                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    return;
+                }
+            };
             let parsed: serde_json::Value = match serde_json::from_str(body) {
                 Ok(v) => v,
                 Err(_) => {
@@ -1293,9 +1313,9 @@ fn handle_connection(stream: TcpStream) {
                 }
             };
             let room_label = parsed["room"].as_str().map(|s| s.to_string());
-            match chat::task_add(&title, room_label.as_deref()) {
+            match chat::task_add_as(&agent_id, &title, room_label.as_deref()) {
                 Ok(id) => {
-                    let resp = serde_json::json!({"id": id, "title": title, "status": "open"});
+                    let resp = serde_json::json!({"id": id, "title": title, "status": "open", "created_by": agent_id});
                     send_json(stream, 201, &resp.to_string());
                 }
                 Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
@@ -1633,6 +1653,24 @@ mod tests {
         assert_eq!(get_header(raw, "stripe-signature"), Some("t=123,v1=abc"));
         assert_eq!(get_header(raw, "content-type"), Some("application/json"));
         assert_eq!(get_header(raw, "X-Missing"), None);
+    }
+
+    #[test]
+    fn test_bearer_token_extracts_authorization_header() {
+        let raw = "POST /api/v1/tasks HTTP/1.1\r\nAuthorization: Bearer abc.def\r\n\r\n{}";
+        assert_eq!(bearer_token(raw), Some("abc.def"));
+    }
+
+    #[test]
+    fn test_verify_bearer_agent_token_accepts_valid_token() {
+        let _guard = crate::store::test_env_lock().lock().unwrap();
+        unsafe {
+            std::env::set_var("AGORA_SANDBOX_SECRET", "serve-test-secret");
+        }
+        let token = crate::sandbox::generate_agent_token("api-agent", 1);
+        let raw = format!("POST /api/v1/tasks HTTP/1.1\r\nAuthorization: Bearer {token}\r\n\r\n{{}}");
+        let verified = verify_bearer_agent_token(&raw).expect("token should verify");
+        assert_eq!(verified, "api-agent");
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- require Authorization: Bearer <agent-token> on POST /api/v1/tasks
- verify the bearer with the existing signed agent token path before accepting API task creation
- create tasks and emit room messages as the verified caller instead of the server process identity

Notes:
- this intentionally reuses the existing signed agent token mechanism already used by sandbox endpoints
- read-only task listing remains public; only the write path is gated

Validation:
- cargo test task_add_as_records_verified_creator -- --nocapture
- cargo test test_verify_bearer_agent_token_accepts_valid_token -- --nocapture
- cargo test test_bearer_token_extracts_authorization_header -- --nocapture
- cargo build --release