### PR TITLE
Economics: escrow bounty rewards at post time

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1708,6 +1708,22 @@ pub fn bounty_post(
     let reward_label = reward_credits
         .map(|c| format!(", reward: {c} credits"))
         .unwrap_or_default();
+
+    if let Some(reward) = reward_credits {
+        let balance = store::credit_balance(&room.room_id, &me);
+        if balance < reward {
+            return Err(format!(
+                "Insufficient credits to post bounty: have {balance}, reward is {reward}"
+            ));
+        }
+        store::credit_add(
+            &room.room_id,
+            &me,
+            -reward,
+            &format!("bounty escrow: {title} ({})", &id[..6]),
+        );
+    }
+
     let mut env = json!({
         "v": VERSION, "id": id, "from": me, "ts": now(),
         "type": "bounty",
@@ -1933,6 +1949,7 @@ pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) ->
     let reward_credits = task.reward_credits;
     let reward_trust = task.reward_trust;
     let task_title = task.title.clone();
+    let task_poster = task.created_by.clone();
     let task_id_short = task_id[..6.min(task_id.len())].to_string();
     if passed {
         task.status = "done".to_string();
@@ -1944,14 +1961,12 @@ pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) ->
     let result = if passed { "PASS" } else { "FAIL" };
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
 
-    // Auto-distribute credits and trust when oracle passes
     if passed {
-        // Issue a work receipt for the winning agent
         let receipt_task = store::Task {
             id: task_id.to_string(),
             title: task_title.clone(),
             status: "done".to_string(),
-            created_by: String::new(),
+            created_by: task_poster.clone(),
             claimed_by: Some(agent_id.to_string()),
             created_at: now(),
             updated_at: now(),
@@ -1961,11 +1976,24 @@ pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) ->
             reward_trust,
             submissions: vec![],
         };
-        publish_task_receipt(&room, &receipt_task, agent_id, "done", Some(&format!("oracle:{oracle}")), now());
+        publish_task_receipt(
+            &room,
+            &receipt_task,
+            agent_id,
+            "done",
+            Some(&format!("oracle:{oracle}")),
+            now(),
+        );
+    }
 
-        // Grant credits if configured on the bounty
-        if let Some(credits) = reward_credits {
-            store::credit_add(&room.room_id, agent_id, credits, &format!("bounty oracle PASS: {task_title} ({task_id_short})"));
+    if let Some(credits) = reward_credits {
+        if passed {
+            store::credit_add(
+                &room.room_id,
+                agent_id,
+                credits,
+                &format!("bounty oracle PASS: {task_title} ({task_id_short})"),
+            );
             let balance = store::credit_balance(&room.room_id, agent_id);
             let credit_env = make_envelope(
                 &format!("[bounty reward] +{credits} credits to {agent_id} for bounty '{task_title}' (balance: {balance})"),
@@ -1974,11 +2002,25 @@ pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) ->
             let enc = encrypt_envelope(&credit_env, &room_key, &room.room_id);
             transport::publish(&room.room_id, &enc);
             store::save_message(&room.room_id, &credit_env);
+        } else if !task_poster.is_empty() {
+            store::credit_add(
+                &room.room_id,
+                &task_poster,
+                credits,
+                &format!("bounty escrow refund: {task_title} ({task_id_short}) — oracle FAIL"),
+            );
         }
+    }
 
-        // Grant trust points if configured on the bounty
+    if passed {
         if let Some(trust) = reward_trust {
-            store::trust_add(&room.room_id, agent_id, trust, &format!("bounty oracle PASS: {task_title}"), "oracle");
+            store::trust_add(
+                &room.room_id,
+                agent_id,
+                trust,
+                &format!("bounty oracle PASS: {task_title}"),
+                "oracle",
+            );
         }
     }
 
@@ -4145,7 +4187,8 @@ mod tests {
         role_heartbeat, role_release, payment_complete_solana_deposit,
         seed_plaza_rate_limit_state, send_watch_heartbeat,
         should_display_message, signing_message_bytes, soma_churn_decay, soma_correct,
-        bounty_submit, bounty_verify, stale_claim_weight, task_add, task_add_as, task_add_with_oracle,
+        bounty_post, bounty_submit, bounty_verify, stale_claim_weight, task_add, task_add_as,
+        task_add_with_oracle,
         task_checkpoint, task_done, unpin,
         verified_solana_deposit_from_tx, SignedWirePayload, VerifiedSolanaDeposit,
         SIGNED_WIRE_VERSION, BASE64, DISCOVERY_POSITIVE_HALF_LIFE_SECS,
@@ -4155,7 +4198,7 @@ mod tests {
     use crate::crypto;
     use crate::store::{self, Role};
     use serde_json::json;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_home() -> PathBuf {
@@ -4264,6 +4307,20 @@ mod tests {
             .current_dir(cwd)
             .output()
             .unwrap()
+    }
+
+    struct CurrentDirGuard(PathBuf);
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.0);
+        }
+    }
+
+    fn enter_manifest_dir() -> CurrentDirGuard {
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(Path::new(env!("CARGO_MANIFEST_DIR"))).unwrap();
+        CurrentDirGuard(original)
     }
 
     #[test]
@@ -4929,6 +4986,7 @@ mod tests {
     #[test]
     fn bounty_verify_awards_credits_to_winner() {
         let _guard = store::test_env_lock().lock().unwrap();
+        let _cwd = enter_manifest_dir();
         let agent_id = "bounty-winner";
         let (_home, room) = setup_plaza_room(agent_id, Role::Admin);
 
@@ -4939,9 +4997,7 @@ mod tests {
             .unwrap()
             .as_nanos();
         let branch = format!("test-bounty-verify-{ts}");
-        let _ = std::process::Command::new("git")
-            .args(["branch", &branch])
-            .output();
+        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", &branch]);
 
         // Create a bounty task with a 50-credit reward. Oracle is "true" — always passes.
         let task_id = task_add_with_oracle(
@@ -4997,9 +5053,136 @@ mod tests {
         );
 
         // Clean up the temporary branch.
-        let _ = std::process::Command::new("git")
-            .args(["branch", "-D", &branch])
-            .output();
+        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", "-D", &branch]);
+    }
+
+    #[test]
+    fn bounty_post_escrows_credits_and_verify_pays_winner() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let _cwd = enter_manifest_dir();
+        let poster_id = "bounty-poster-escrow";
+        let winner_id = "bounty-winner-escrow";
+        let (_home, room) = setup_plaza_room(poster_id, Role::Admin);
+
+        store::credit_add(&room.room_id, poster_id, 100, "test setup");
+        assert_eq!(store::credit_balance(&room.room_id, poster_id), 100);
+
+        bounty_post("Escrow test task", 1, Some("true"), Some(60), None)
+            .expect("bounty_post should succeed with sufficient credits");
+
+        assert_eq!(
+            store::credit_balance(&room.room_id, poster_id),
+            40,
+            "poster should have 40 credits after escrow"
+        );
+
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let branch = format!("test-escrow-verify-{ts}");
+        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", &branch]);
+
+        let mut tasks = store::load_tasks(&room.room_id);
+        let task = tasks
+            .iter_mut()
+            .find(|t| t.title == "Escrow test task")
+            .expect("task created");
+        task.submissions.push(store::BountySubmission {
+            agent_id: winner_id.to_string(),
+            branch: branch.clone(),
+            submitted_at: 0,
+            oracle_passed: None,
+        });
+        let task_id = task.id.clone();
+        store::save_tasks(&room.room_id, &tasks);
+
+        let result = bounty_verify(&task_id, winner_id, None).expect("bounty_verify should succeed");
+        assert!(result.starts_with("PASS"), "oracle 'true' must PASS, got: {result}");
+
+        assert_eq!(
+            store::credit_balance(&room.room_id, winner_id),
+            60,
+            "winner should receive the 60 escrowed credits"
+        );
+        assert_eq!(
+            store::credit_balance(&room.room_id, poster_id),
+            40,
+            "poster retains remaining credits after bounty payout"
+        );
+
+        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", "-D", &branch]);
+    }
+
+    #[test]
+    fn bounty_post_rejects_insufficient_credits() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let poster_id = "bounty-poster-broke";
+        let (_home, _room) = setup_plaza_room(poster_id, Role::Admin);
+
+        let result = bounty_post("No-funds bounty", 1, Some("true"), Some(50), None);
+        assert!(result.is_err(), "bounty_post must reject insufficient credits");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Insufficient credits"),
+            "error must mention insufficient credits, got: {err}"
+        );
+    }
+
+    #[test]
+    fn bounty_verify_refunds_escrow_on_fail() {
+        let _guard = store::test_env_lock().lock().unwrap();
+        let _cwd = enter_manifest_dir();
+        let poster_id = "bounty-poster-refund";
+        let submitter_id = "bounty-submitter-fail";
+        let (_home, room) = setup_plaza_room(poster_id, Role::Admin);
+
+        store::credit_add(&room.room_id, poster_id, 80, "test setup");
+        bounty_post("Refund test task", 1, Some("false"), Some(50), None)
+            .expect("bounty_post should succeed");
+        assert_eq!(
+            store::credit_balance(&room.room_id, poster_id),
+            30,
+            "poster should have 30 credits after escrow"
+        );
+
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let branch = format!("test-refund-verify-{ts}");
+        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", &branch]);
+
+        let mut tasks = store::load_tasks(&room.room_id);
+        let task = tasks
+            .iter_mut()
+            .find(|t| t.title == "Refund test task")
+            .expect("task created");
+        task.submissions.push(store::BountySubmission {
+            agent_id: submitter_id.to_string(),
+            branch: branch.clone(),
+            submitted_at: 0,
+            oracle_passed: None,
+        });
+        let task_id = task.id.clone();
+        store::save_tasks(&room.room_id, &tasks);
+
+        let result =
+            bounty_verify(&task_id, submitter_id, None).expect("bounty_verify should report FAIL");
+        assert!(result.starts_with("FAIL"), "oracle 'false' must FAIL, got: {result}");
+
+        assert_eq!(
+            store::credit_balance(&room.room_id, submitter_id),
+            0,
+            "submitter should receive nothing on FAIL"
+        );
+        assert_eq!(
+            store::credit_balance(&room.room_id, poster_id),
+            80,
+            "poster escrow must be refunded on FAIL"
+        );
+
+        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", "-D", &branch]);
     }
 
     /// Verify that a bounty poster cannot submit to their own bounty (anti-self-dealing).


### PR DESCRIPTION
## Summary
- require bounty posters to already hold the credited reward and escrow it when posting
- pay the winner from escrow on oracle PASS and refund the poster on oracle FAIL
- add regression tests for escrow payout, insufficient-balance rejection, and refund-on-fail

## Validation
- cargo test bounty_ -- --nocapture
- cargo build --release