### PR TITLE
devops: fix cargo fmt violations + enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,21 @@ on:
     branches: [main]
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust + rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check
+
   build:
+    needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +49,7 @@ jobs:
         run: ls -lh target/release/agora
 
   static-binary:
+    needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -179,9 +179,8 @@ fn auth_warning_id(
     reason: &str,
 ) -> String {
     use ring::digest;
-    let input = format!(
-        "agora-auth-warning-v1\n{room_id}\n{sender}\n{signing_pubkey}\n{sig}\n{reason}"
-    );
+    let input =
+        format!("agora-auth-warning-v1\n{room_id}\n{sender}\n{signing_pubkey}\n{sig}\n{reason}");
     let hash = digest::digest(&digest::SHA256, input.as_bytes());
     format!("auth-{}", hex::encode(&hash.as_ref()[..4]))
 }
@@ -519,11 +518,13 @@ fn parse_envelope(raw: &str) -> Option<serde_json::Value> {
     None
 }
 
-fn signing_message_bytes(room_id: &str, from: &str, signing_pubkey: &str, payload: &str) -> Vec<u8> {
-    format!(
-        "agora-signed-wire-v1\n{room_id}\n{from}\n{signing_pubkey}\n{payload}"
-    )
-    .into_bytes()
+fn signing_message_bytes(
+    room_id: &str,
+    from: &str,
+    signing_pubkey: &str,
+    payload: &str,
+) -> Vec<u8> {
+    format!("agora-signed-wire-v1\n{room_id}\n{from}\n{signing_pubkey}\n{payload}").into_bytes()
 }
 
 // ── Encrypt / Decrypt ───────────────────────────────────────────
@@ -542,9 +543,8 @@ fn encrypt_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str)
     store::trust_signing_key(from, &signing_pubkey);
 
     let signing_input = signing_message_bytes(room_id, from, &signing_pubkey, &payload);
-    let sig = BASE64.encode(
-        crypto::sign_message(&pkcs8, &signing_input).expect("message signing failed")
-    );
+    let sig = BASE64
+        .encode(crypto::sign_message(&pkcs8, &signing_input).expect("message signing failed"));
 
     serde_json::to_string(&SignedWirePayload {
         v: SIGNED_WIRE_VERSION.to_string(),
@@ -556,7 +556,11 @@ fn encrypt_envelope(env: &serde_json::Value, room_key: &[u8; 32], room_id: &str)
     .unwrap()
 }
 
-fn decrypt_signed_payload(raw: &str, room_key: &[u8; 32], room_id: &str) -> Option<serde_json::Value> {
+fn decrypt_signed_payload(
+    raw: &str,
+    room_key: &[u8; 32],
+    room_id: &str,
+) -> Option<serde_json::Value> {
     let wire = serde_json::from_str::<SignedWirePayload>(raw).ok()?;
     let signing_input =
         signing_message_bytes(room_id, &wire.from, &wire.signing_pubkey, &wire.payload);
@@ -680,7 +684,9 @@ pub fn leave(room_label: Option<&str>) -> Result<serde_json::Value, String> {
 
     if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
-            unsafe { libc::kill(pid, libc::SIGTERM); }
+            unsafe {
+                libc::kill(pid, libc::SIGTERM);
+            }
             daemon_stopped = true;
         }
         let _ = std::fs::remove_file(&pid_path);
@@ -709,7 +715,11 @@ pub fn heartbeat(room_label: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
-pub fn send(message: &str, reply_to: Option<&str>, room_label: Option<&str>) -> Result<String, String> {
+pub fn send(
+    message: &str,
+    reply_to: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let sender = store::get_agent_id();
     enforce_outbound_plaza_rate_limit(&room, &sender)?;
@@ -783,7 +793,11 @@ pub fn redeem_invite(
     Ok(())
 }
 
-pub fn read(since: &str, limit: usize, room_label: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+pub fn read(
+    since: &str,
+    limit: usize,
+    room_label: Option<&str>,
+) -> Result<Vec<serde_json::Value>, String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
     let since_secs = parse_since(since);
@@ -875,7 +889,8 @@ pub fn check(since: &str, room_label: Option<&str>) -> Result<Vec<serde_json::Va
             if is_receipt(&env) {
                 if let Some(ids) = env["read_ids"].as_array() {
                     let reader = from.to_string();
-                    let msg_ids: Vec<String> = ids.iter()
+                    let msg_ids: Vec<String> = ids
+                        .iter()
                         .filter_map(|v| v.as_str().map(|s| s.to_string()))
                         .collect();
                     store::record_receipts(&room.room_id, &msg_ids, &reader);
@@ -912,7 +927,9 @@ pub fn check(since: &str, room_label: Option<&str>) -> Result<Vec<serde_json::Va
 
             // Process incoming reactions
             if is_reaction(&env) {
-                if let (Some(target), Some(emoji)) = (env["target_id"].as_str(), env["emoji"].as_str()) {
+                if let (Some(target), Some(emoji)) =
+                    (env["target_id"].as_str(), env["emoji"].as_str())
+                {
                     store::add_reaction(&room.room_id, target, from, emoji);
                 }
                 continue;
@@ -982,7 +999,9 @@ pub fn react(target_id: &str, emoji: &str, room_label: Option<&str>) -> Result<(
 }
 
 /// Get reactions for recent messages.
-pub fn reactions(room_label: Option<&str>) -> Result<std::collections::HashMap<String, Vec<(String, String)>>, String> {
+pub fn reactions(
+    room_label: Option<&str>,
+) -> Result<std::collections::HashMap<String, Vec<(String, String)>>, String> {
     let room = resolve_room(room_label)?;
     Ok(store::load_reactions(&room.room_id))
 }
@@ -1008,7 +1027,11 @@ pub fn muted(room_label: Option<&str>) -> Result<std::collections::HashSet<Strin
 }
 
 /// Set your agent profile and broadcast it to the room.
-pub fn set_profile(name: Option<&str>, role: Option<&str>, room_label: Option<&str>) -> Result<(), String> {
+pub fn set_profile(
+    name: Option<&str>,
+    role: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<(), String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
     let agent_id = store::get_agent_id();
@@ -1041,7 +1064,10 @@ pub fn set_profile(name: Option<&str>, role: Option<&str>, room_label: Option<&s
 }
 
 /// Look up an agent's profile.
-pub fn whois(agent_id: &str, room_label: Option<&str>) -> Result<Option<store::AgentProfile>, String> {
+pub fn whois(
+    agent_id: &str,
+    room_label: Option<&str>,
+) -> Result<Option<store::AgentProfile>, String> {
     let room = resolve_room(room_label)?;
     Ok(store::get_profile(&room.room_id, agent_id))
 }
@@ -1166,7 +1192,10 @@ pub fn role_release(role: &str, room_label: Option<&str>) -> Result<(), String> 
         .ok_or_else(|| format!("Role '{}' is not currently claimed.", role))?;
 
     if existing.agent_id != me && existing.lease_expires > now_ts {
-        return Err(format!("Role '{}' is currently held by '{}'.", role, existing.agent_id));
+        return Err(format!(
+            "Role '{}' is currently held by '{}'.",
+            role, existing.agent_id
+        ));
     }
 
     let released = store::RoleLease {
@@ -1192,7 +1221,12 @@ pub fn list_role_leases(room_label: Option<&str>) -> Result<Vec<store::RoleLease
 
 // ── Credits / Agent Economy ────────────────────────────────────
 
-pub fn credit_grant(agent_id: &str, amount: i64, reason: &str, room_label: Option<&str>) -> Result<i64, String> {
+pub fn credit_grant(
+    agent_id: &str,
+    amount: i64,
+    reason: &str,
+    room_label: Option<&str>,
+) -> Result<i64, String> {
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
     // Bootstrap: if no admin exists, first granter becomes admin
@@ -1205,17 +1239,26 @@ pub fn credit_grant(agent_id: &str, amount: i64, reason: &str, room_label: Optio
     store::credit_add(&room.room_id, agent_id, amount, reason);
     let balance = store::credit_balance(&room.room_id, agent_id);
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("[credit] +{amount} to {agent_id}: {reason} (balance: {balance})"), None);
+    let env = make_envelope(
+        &format!("[credit] +{amount} to {agent_id}: {reason} (balance: {balance})"),
+        None,
+    );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
     Ok(balance)
 }
 
-pub fn credit_balance_check(agent_id: Option<&str>, room_label: Option<&str>) -> Result<(i64, i64), String> {
+pub fn credit_balance_check(
+    agent_id: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<(i64, i64), String> {
     let room = resolve_room(room_label)?;
     let id = agent_id.unwrap_or(&store::get_agent_id()).to_string();
-    Ok((store::credit_balance(&room.room_id, &id), store::trust_balance(&room.room_id, &id)))
+    Ok((
+        store::credit_balance(&room.room_id, &id),
+        store::trust_balance(&room.room_id, &id),
+    ))
 }
 
 /// Compute a live trust score for an agent across all joined rooms.
@@ -1232,12 +1275,19 @@ pub fn compute_agent_trust_score(agent_id: &str) -> (f64, usize, usize, usize) {
     for room in &rooms {
         let receipts = store::load_work_receipts(&room.room_id);
         let agent_receipts: Vec<_> = receipts.iter().filter(|r| r.agent_id == agent_id).collect();
-        if agent_receipts.is_empty() { continue; }
+        if agent_receipts.is_empty() {
+            continue;
+        }
         rooms_active += 1;
         total_receipt_count += agent_receipts.len();
         total_weighted_receipts += agent_receipts
             .iter()
-            .map(|r| discovery_decay_weight(now_ts.saturating_sub(r.created_at), DISCOVERY_POSITIVE_HALF_LIFE_SECS))
+            .map(|r| {
+                discovery_decay_weight(
+                    now_ts.saturating_sub(r.created_at),
+                    DISCOVERY_POSITIVE_HALF_LIFE_SECS,
+                )
+            })
             .sum::<f64>();
 
         // Stale claims penalty
@@ -1259,7 +1309,8 @@ pub fn compute_agent_trust_score(agent_id: &str) -> (f64, usize, usize, usize) {
         0.0
     };
     let abandonment_penalty = (1.0 - abandonment_rate * 0.7).clamp(0.2, 1.0);
-    let positive_score = (1.0 + total_weighted_receipts) * room_presence * (1.0 + vouches as f64 * 0.3);
+    let positive_score =
+        (1.0 + total_weighted_receipts) * room_presence * (1.0 + vouches as f64 * 0.3);
     let score = positive_score * abandonment_penalty;
 
     (score, total_receipt_count, rooms_active, vouches)
@@ -1269,7 +1320,11 @@ pub fn credit_spend(amount: i64, reason: &str, room_label: Option<&str>) -> Resu
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
     let balance = store::credit_balance(&room.room_id, &me);
-    if balance < amount { return Err(format!("Insufficient credits: have {balance}, need {amount}")); }
+    if balance < amount {
+        return Err(format!(
+            "Insufficient credits: have {balance}, need {amount}"
+        ));
+    }
     store::credit_add(&room.room_id, &me, -amount, reason);
     Ok(balance - amount)
 }
@@ -1281,9 +1336,13 @@ pub fn bet_create(question: &str, room_label: Option<&str>) -> Result<String, St
     let me = store::get_agent_id();
     let id = msg_id();
     let bet = store::Bet {
-        id: id.clone(), question: question.to_string(), created_by: me.clone(),
-        created_at: now(), status: "open".to_string(),
-        stakes_yes: Vec::new(), stakes_no: Vec::new(),
+        id: id.clone(),
+        question: question.to_string(),
+        created_by: me.clone(),
+        created_at: now(),
+        status: "open".to_string(),
+        stakes_yes: Vec::new(),
+        stakes_no: Vec::new(),
     };
     let mut bets = store::load_bets(&room.room_id);
     bets.push(bet);
@@ -1297,45 +1356,94 @@ pub fn bet_create(question: &str, room_label: Option<&str>) -> Result<String, St
     Ok(id)
 }
 
-pub fn bet_stake(bet_id: &str, side: bool, amount: i64, room_label: Option<&str>) -> Result<(), String> {
+pub fn bet_stake(
+    bet_id: &str,
+    side: bool,
+    amount: i64,
+    room_label: Option<&str>,
+) -> Result<(), String> {
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
     let balance = store::credit_balance(&room.room_id, &me);
-    if balance < amount { return Err(format!("Insufficient credits: have {balance}, need {amount}")); }
+    if balance < amount {
+        return Err(format!(
+            "Insufficient credits: have {balance}, need {amount}"
+        ));
+    }
 
     let mut bets = store::load_bets(&room.room_id);
-    let bet = bets.iter_mut().find(|b| b.id.starts_with(bet_id) && b.status == "open")
+    let bet = bets
+        .iter_mut()
+        .find(|b| b.id.starts_with(bet_id) && b.status == "open")
         .ok_or("Bet not found or already resolved")?;
 
-    if side { bet.stakes_yes.push((me.clone(), amount)); }
-    else { bet.stakes_no.push((me.clone(), amount)); }
+    if side {
+        bet.stakes_yes.push((me.clone(), amount));
+    } else {
+        bet.stakes_no.push((me.clone(), amount));
+    }
     store::save_bets(&room.room_id, &bets);
 
     // Escrow: debit the staker
-    store::credit_add(&room.room_id, &me, -amount, &format!("bet escrow: {} on {}", if side {"YES"} else {"NO"}, &bet_id[..6.min(bet_id.len())]));
+    store::credit_add(
+        &room.room_id,
+        &me,
+        -amount,
+        &format!(
+            "bet escrow: {} on {}",
+            if side { "YES" } else { "NO" },
+            &bet_id[..6.min(bet_id.len())]
+        ),
+    );
 
     let side_str = if side { "YES" } else { "NO" };
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("[bet] {me} stakes {amount} on {side_str} (bet {})", &bet_id[..6.min(bet_id.len())]), None);
+    let env = make_envelope(
+        &format!(
+            "[bet] {me} stakes {amount} on {side_str} (bet {})",
+            &bet_id[..6.min(bet_id.len())]
+        ),
+        None,
+    );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
     Ok(())
 }
 
-pub fn bet_resolve(bet_id: &str, outcome: bool, room_label: Option<&str>) -> Result<String, String> {
+pub fn bet_resolve(
+    bet_id: &str,
+    outcome: bool,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
-    if !store::is_admin(&room.room_id, &me) { return Err("Only admins can resolve bets.".to_string()); }
+    if !store::is_admin(&room.room_id, &me) {
+        return Err("Only admins can resolve bets.".to_string());
+    }
 
     let mut bets = store::load_bets(&room.room_id);
-    let idx = bets.iter().position(|b| b.id.starts_with(bet_id) && b.status == "open")
+    let idx = bets
+        .iter()
+        .position(|b| b.id.starts_with(bet_id) && b.status == "open")
         .ok_or("Bet not found or already resolved")?;
 
-    bets[idx].status = if outcome { "resolved_yes".to_string() } else { "resolved_no".to_string() };
+    bets[idx].status = if outcome {
+        "resolved_yes".to_string()
+    } else {
+        "resolved_no".to_string()
+    };
 
-    let winners = if outcome { bets[idx].stakes_yes.clone() } else { bets[idx].stakes_no.clone() };
-    let losers = if outcome { bets[idx].stakes_no.clone() } else { bets[idx].stakes_yes.clone() };
+    let winners = if outcome {
+        bets[idx].stakes_yes.clone()
+    } else {
+        bets[idx].stakes_no.clone()
+    };
+    let losers = if outcome {
+        bets[idx].stakes_no.clone()
+    } else {
+        bets[idx].stakes_yes.clone()
+    };
 
     let total_pot: i64 = losers.iter().map(|(_, a)| a).sum();
     let winner_total: i64 = winners.iter().map(|(_, a)| a).sum();
@@ -1343,9 +1451,18 @@ pub fn bet_resolve(bet_id: &str, outcome: bool, room_label: Option<&str>) -> Res
 
     let mut payouts = Vec::new();
     for (agent, stake) in &winners {
-        let share = if winner_total > 0 { (*stake as f64 / winner_total as f64 * total_pot as f64) as i64 } else { 0 };
+        let share = if winner_total > 0 {
+            (*stake as f64 / winner_total as f64 * total_pot as f64) as i64
+        } else {
+            0
+        };
         let payout = stake + share;
-        store::credit_add(&room.room_id, agent, payout, &format!("bet won: {}", &bet_id[..6.min(bet_id.len())]));
+        store::credit_add(
+            &room.room_id,
+            agent,
+            payout,
+            &format!("bet won: {}", &bet_id[..6.min(bet_id.len())]),
+        );
         payouts.push(format!("{}: +{}", agent, payout));
     }
 
@@ -1353,11 +1470,24 @@ pub fn bet_resolve(bet_id: &str, outcome: bool, room_label: Option<&str>) -> Res
 
     let outcome_str = if outcome { "YES" } else { "NO" };
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("[bet resolved] {} → {} | Pot: {} | {}", question, outcome_str, total_pot, payouts.join(", ")), None);
+    let env = make_envelope(
+        &format!(
+            "[bet resolved] {} → {} | Pot: {} | {}",
+            question,
+            outcome_str,
+            total_pot,
+            payouts.join(", ")
+        ),
+        None,
+    );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
-    Ok(format!("Resolved: {} → {outcome_str}, pot {total_pot} distributed to {} winners", question, winners.len()))
+    Ok(format!(
+        "Resolved: {} → {outcome_str}, pot {total_pot} distributed to {} winners",
+        question,
+        winners.len()
+    ))
 }
 
 pub fn bet_list(room_label: Option<&str>) -> Result<Vec<store::Bet>, String> {
@@ -1429,7 +1559,11 @@ pub fn gap_list() -> Vec<CapabilityGap> {
         seen.entry(key).or_insert(gap);
     }
     let mut result: Vec<_> = seen.into_values().collect();
-    result.sort_by(|a, b| b.urgency.cmp(&a.urgency).then(b.blocked_tasks.cmp(&a.blocked_tasks)));
+    result.sort_by(|a, b| {
+        b.urgency
+            .cmp(&a.urgency)
+            .then(b.blocked_tasks.cmp(&a.blocked_tasks))
+    });
     result
 }
 
@@ -1448,12 +1582,23 @@ pub fn directory() -> Result<Vec<RoomInfo>, String> {
     let mut infos = Vec::new();
     for room in &rooms {
         let msgs = store::load_messages(&room.room_id, 86400);
-        let online = room.members.iter().filter(|m| m.last_seen > 0 && now_ts - m.last_seen < 300).count();
-        let last_ts = msgs.iter().map(|m| m["ts"].as_u64().unwrap_or(0)).max().unwrap_or(0);
+        let online = room
+            .members
+            .iter()
+            .filter(|m| m.last_seen > 0 && now_ts - m.last_seen < 300)
+            .count();
+        let last_ts = msgs
+            .iter()
+            .map(|m| m["ts"].as_u64().unwrap_or(0))
+            .max()
+            .unwrap_or(0);
         infos.push(RoomInfo {
-            label: room.label.clone(), room_id: room.room_id.clone(),
-            topic: room.topic.clone(), agent_count: online,
-            message_count: msgs.len(), last_activity: last_ts,
+            label: room.label.clone(),
+            room_id: room.room_id.clone(),
+            topic: room.topic.clone(),
+            agent_count: online,
+            message_count: msgs.len(),
+            last_activity: last_ts,
         });
     }
     infos.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
@@ -1462,12 +1607,19 @@ pub fn directory() -> Result<Vec<RoomInfo>, String> {
 
 // ── Capability Cards ───────────────────────────────────────────
 
-pub fn card_set(capabilities: &[String], description: Option<&str>, room_label: Option<&str>) -> Result<(), String> {
+pub fn card_set(
+    capabilities: &[String],
+    description: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<(), String> {
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
     let card = store::CapabilityCard {
-        agent_id: me.clone(), capabilities: capabilities.to_vec(),
-        available: true, description: description.map(|s| s.to_string()), updated_at: now(),
+        agent_id: me.clone(),
+        capabilities: capabilities.to_vec(),
+        available: true,
+        description: description.map(|s| s.to_string()),
+        updated_at: now(),
     };
     store::save_card(&card);
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
@@ -1483,8 +1635,13 @@ pub fn card_set(capabilities: &[String], description: Option<&str>, room_label: 
     Ok(())
 }
 
-pub fn card_show(agent_id: Option<&str>, room_label: Option<&str>) -> Result<Option<store::CapabilityCard>, String> {
-    if agent_id.is_none() { return Ok(store::load_card()); }
+pub fn card_show(
+    agent_id: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<Option<store::CapabilityCard>, String> {
+    if agent_id.is_none() {
+        return Ok(store::load_card());
+    }
     let room = resolve_room(room_label)?;
     let cards = store::load_peer_cards(&room.room_id);
     Ok(cards.into_iter().find(|c| c.agent_id == agent_id.unwrap()))
@@ -1529,17 +1686,28 @@ pub fn discover(need: &str, room_label: Option<&str>) -> Result<Vec<DiscoveryRes
         let receipts = store::load_work_receipts(&room.room_id);
         let tasks = task_list(Some(&room.room_id))?;
         for card in store::load_peer_cards(&room.room_id) {
-            let matches = needs.iter().all(|n| card.capabilities.iter().any(|c| c.to_lowercase().contains(n)));
-            if !matches { continue; }
+            let matches = needs.iter().all(|n| {
+                card.capabilities
+                    .iter()
+                    .any(|c| c.to_lowercase().contains(n))
+            });
+            if !matches {
+                continue;
+            }
 
-            let agent_receipts: Vec<_> = receipts.iter().filter(|r| r.agent_id == card.agent_id).collect();
+            let agent_receipts: Vec<_> = receipts
+                .iter()
+                .filter(|r| r.agent_id == card.agent_id)
+                .collect();
             let receipt_count = agent_receipts.len();
             let weighted_receipts = agent_receipts
                 .iter()
-                .map(|receipt| discovery_decay_weight(
-                    now_ts.saturating_sub(receipt.created_at),
-                    DISCOVERY_POSITIVE_HALF_LIFE_SECS,
-                ))
+                .map(|receipt| {
+                    discovery_decay_weight(
+                        now_ts.saturating_sub(receipt.created_at),
+                        DISCOVERY_POSITIVE_HALF_LIFE_SECS,
+                    )
+                })
                 .sum::<f64>();
             let freshest_receipt = agent_receipts
                 .iter()
@@ -1547,7 +1715,10 @@ pub fn discover(need: &str, room_label: Option<&str>) -> Result<Vec<DiscoveryRes
                 .max();
             let stale_claims: Vec<_> = tasks
                 .iter()
-                .filter(|task| task.status != "done" && task.claimed_by.as_deref() == Some(card.agent_id.as_str()))
+                .filter(|task| {
+                    task.status != "done"
+                        && task.claimed_by.as_deref() == Some(card.agent_id.as_str())
+                })
                 .filter_map(|task| {
                     let age = now_ts.saturating_sub(task.updated_at);
                     let weight = stale_claim_weight(age);
@@ -1562,19 +1733,27 @@ pub fn discover(need: &str, room_label: Option<&str>) -> Result<Vec<DiscoveryRes
                 DISCOVERY_POSITIVE_HALF_LIFE_SECS,
             );
             let execution_freshness = freshest_receipt
-                .map(|ts| discovery_decay_weight(now_ts.saturating_sub(ts), DISCOVERY_POSITIVE_HALF_LIFE_SECS))
+                .map(|ts| {
+                    discovery_decay_weight(
+                        now_ts.saturating_sub(ts),
+                        DISCOVERY_POSITIVE_HALF_LIFE_SECS,
+                    )
+                })
                 .unwrap_or(0.0);
             let volatility = (card_freshness - execution_freshness).max(0.0);
 
-            let entry = agent_map.entry(card.agent_id.clone()).or_insert_with(|| DiscoveryAccumulator {
-                card: card.clone(),
-                receipt_count: 0,
-                rooms_active: 0,
-                weighted_receipts: 0.0,
-                stale_claims: 0,
-                stale_claim_weight: 0.0,
-                volatility_sum: 0.0,
-            });
+            let entry =
+                agent_map
+                    .entry(card.agent_id.clone())
+                    .or_insert_with(|| DiscoveryAccumulator {
+                        card: card.clone(),
+                        receipt_count: 0,
+                        rooms_active: 0,
+                        weighted_receipts: 0.0,
+                        stale_claims: 0,
+                        stale_claim_weight: 0.0,
+                        volatility_sum: 0.0,
+                    });
             if card.updated_at > entry.card.updated_at {
                 entry.card = card.clone();
             }
@@ -1602,7 +1781,8 @@ pub fn discover(need: &str, room_label: Option<&str>) -> Result<Vec<DiscoveryRes
                 0.0
             };
             let room_presence = 1.0 + entry.rooms_active as f64 * 0.2;
-            let positive_score = (1.0 + entry.weighted_receipts) * room_presence * (1.0 + vouches * 0.3);
+            let positive_score =
+                (1.0 + entry.weighted_receipts) * room_presence * (1.0 + vouches * 0.3);
             let abandonment_penalty = (1.0 - abandonment_rate * 0.7).clamp(0.2, 1.0);
             let volatility_penalty = (1.0 - volatility_score * 0.4).clamp(0.4, 1.0);
             DiscoveryResult {
@@ -1616,7 +1796,11 @@ pub fn discover(need: &str, room_label: Option<&str>) -> Result<Vec<DiscoveryRes
             }
         })
         .collect();
-    results.sort_by(|a, b| b.trust_score.partial_cmp(&a.trust_score).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| {
+        b.trust_score
+            .partial_cmp(&a.trust_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     Ok(results)
 }
 
@@ -1635,14 +1819,24 @@ fn stale_claim_weight(age_secs: u64) -> f64 {
 }
 
 pub fn process_card_message(room_id: &str, msg: &serde_json::Value) {
-    if msg["type"].as_str() != Some("capability_card") { return; }
+    if msg["type"].as_str() != Some("capability_card") {
+        return;
+    }
     let agent_id = msg["from"].as_str().unwrap_or("").to_string();
-    if agent_id.is_empty() { return; }
-    let caps: Vec<String> = msg["capabilities"].as_array()
-        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+    if agent_id.is_empty() {
+        return;
+    }
+    let caps: Vec<String> = msg["capabilities"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
         .unwrap_or_default();
     let card = store::CapabilityCard {
-        agent_id, capabilities: caps,
+        agent_id,
+        capabilities: caps,
         available: msg["available"].as_bool().unwrap_or(true),
         description: msg["description"].as_str().map(String::from),
         updated_at: msg["ts"].as_u64().unwrap_or(0),
@@ -1656,7 +1850,9 @@ pub fn process_card_message(room_id: &str, msg: &serde_json::Value) {
 pub fn vouch(agent_id: &str, reason: Option<&str>, room_label: Option<&str>) -> Result<(), String> {
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
-    if me == agent_id { return Err("Cannot vouch for yourself.".to_string()); }
+    if me == agent_id {
+        return Err("Cannot vouch for yourself.".to_string());
+    }
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
     let reason_str = reason.unwrap_or("trusted collaborator");
@@ -1680,7 +1876,9 @@ pub fn vouch_count(agent_id: &str) -> usize {
     for room in &rooms {
         let msgs = store::load_messages(&room.room_id, 604800 * 4); // 4 weeks
         for msg in &msgs {
-            if msg["type"].as_str() == Some("vouch") && msg["vouched_for"].as_str() == Some(agent_id) {
+            if msg["type"].as_str() == Some("vouch")
+                && msg["vouched_for"].as_str() == Some(agent_id)
+            {
                 count += 1;
             }
         }
@@ -1768,7 +1966,14 @@ pub fn bounty_post(
     store::save_message(&room.room_id, &env);
 
     // Also create as a task (with oracle, reward, and deadline)
-    let _ = task_add_with_oracle(title, acceptance_oracle, reward_credits, reward_trust, expires_at, room_label);
+    let _ = task_add_with_oracle(
+        title,
+        acceptance_oracle,
+        reward_credits,
+        reward_trust,
+        expires_at,
+        room_label,
+    );
     Ok(id)
 }
 
@@ -1806,7 +2011,11 @@ fn task_add_with_oracle(
 
 /// Submit a branch as a bounty/task solution.
 /// Records the submission on the task and optionally runs the acceptance oracle.
-pub fn bounty_submit(task_id: &str, branch: &str, room_label: Option<&str>) -> Result<String, String> {
+pub fn bounty_submit(
+    task_id: &str,
+    branch: &str,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
     let now_ts = now();
@@ -1817,7 +2026,9 @@ pub fn bounty_submit(task_id: &str, branch: &str, room_label: Option<&str>) -> R
         let msgs = store::load_messages(&room.room_id, 604800);
         for msg in &msgs {
             if msg["type"].as_str() == Some("bounty")
-                && msg["id"].as_str().map_or(false, |id| id.starts_with(task_id))
+                && msg["id"]
+                    .as_str()
+                    .map_or(false, |id| id.starts_with(task_id))
             {
                 tasks.push(store::Task {
                     id: msg["id"].as_str().unwrap_or(task_id).to_string(),
@@ -1830,7 +2041,8 @@ pub fn bounty_submit(task_id: &str, branch: &str, room_label: Option<&str>) -> R
                     notes: None,
                     acceptance_oracle: msg["acceptance_oracle"].as_str().map(|s| s.to_string()),
                     // Bounty messages may use "reward_credits" or the legacy "reward" key.
-                    reward_credits: msg["reward_credits"].as_i64()
+                    reward_credits: msg["reward_credits"]
+                        .as_i64()
                         .or_else(|| msg["reward"].as_i64()),
                     reward_trust: msg["reward_trust"].as_i64(),
                     submissions: vec![],
@@ -1841,7 +2053,8 @@ pub fn bounty_submit(task_id: &str, branch: &str, room_label: Option<&str>) -> R
         }
     }
 
-    let task = tasks.iter_mut()
+    let task = tasks
+        .iter_mut()
         .find(|t| t.id.starts_with(task_id))
         .ok_or_else(|| format!("No task matching '{task_id}'"))?;
     if task.status != "open" && task.status != "claimed" {
@@ -1859,7 +2072,9 @@ pub fn bounty_submit(task_id: &str, branch: &str, room_label: Option<&str>) -> R
 
     // Prevent bounty poster from submitting to their own bounty (anti-self-dealing)
     if task.created_by == me {
-        return Err(format!("Agent {me} cannot submit to their own bounty (self-dealing not permitted)"));
+        return Err(format!(
+            "Agent {me} cannot submit to their own bounty (self-dealing not permitted)"
+        ));
     }
 
     // Prevent duplicate submissions from same agent
@@ -1902,7 +2117,9 @@ pub fn bounty_submit(task_id: &str, branch: &str, room_label: Option<&str>) -> R
                 store::save_tasks(&room.room_id, &tasks2);
                 let result = if passed { "PASS" } else { "FAIL" };
                 let env2 = make_envelope(
-                    &format!("[bounty oracle] {result}: '{cmd}' on branch '{branch}' (task {task_id})"),
+                    &format!(
+                        "[bounty oracle] {result}: '{cmd}' on branch '{branch}' (task {task_id})"
+                    ),
                     None,
                 );
                 let encrypted2 = encrypt_envelope(&env2, &room_key, &room.room_id);
@@ -1914,7 +2131,9 @@ pub fn bounty_submit(task_id: &str, branch: &str, room_label: Option<&str>) -> R
         }
     }
 
-    Ok(format!("Submitted branch '{branch}' for task '{title}'. No oracle configured — manual review required."))
+    Ok(format!(
+        "Submitted branch '{branch}' for task '{title}'. No oracle configured — manual review required."
+    ))
 }
 
 /// Run a shell command in the context of a git branch (stashes current state, checks out branch, runs, restores).
@@ -1965,17 +2184,24 @@ fn run_oracle_on_branch(branch: &str, oracle_cmd: &str) -> Result<bool, String> 
     let _ = Command::new("git")
         .args(["checkout", "--quiet", &original_branch])
         .output();
-    let _ = Command::new("git").args(["stash", "pop", "--quiet"]).output();
+    let _ = Command::new("git")
+        .args(["stash", "pop", "--quiet"])
+        .output();
 
     result
 }
 
 /// Verify an existing submission by running the oracle now (useful for deferred verification).
-pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) -> Result<String, String> {
+pub fn bounty_verify(
+    task_id: &str,
+    agent_id: &str,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let now_ts = now();
     let mut tasks = store::load_tasks(&room.room_id);
-    let task = tasks.iter_mut()
+    let task = tasks
+        .iter_mut()
         .find(|t| t.id.starts_with(task_id))
         .ok_or_else(|| format!("No task matching '{task_id}'"))?;
     if task.status != "open" && task.status != "claimed" {
@@ -1990,9 +2216,13 @@ pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) ->
             task.id
         ));
     }
-    let oracle = task.acceptance_oracle.clone()
+    let oracle = task
+        .acceptance_oracle
+        .clone()
         .ok_or_else(|| "Task has no acceptance_oracle configured".to_string())?;
-    let sub = task.submissions.iter_mut()
+    let sub = task
+        .submissions
+        .iter_mut()
         .find(|s| s.agent_id.starts_with(agent_id))
         .ok_or_else(|| format!("No submission from agent '{agent_id}'"))?;
     let branch = sub.branch.clone();
@@ -2050,7 +2280,9 @@ pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) ->
             );
             let balance = store::credit_balance(&room.room_id, agent_id);
             let credit_env = make_envelope(
-                &format!("[bounty reward] +{credits} credits to {agent_id} for bounty '{task_title}' (balance: {balance})"),
+                &format!(
+                    "[bounty reward] +{credits} credits to {agent_id} for bounty '{task_title}' (balance: {balance})"
+                ),
                 None,
             );
             let enc = encrypt_envelope(&credit_env, &room_key, &room.room_id);
@@ -2079,7 +2311,9 @@ pub fn bounty_verify(task_id: &str, agent_id: &str, room_label: Option<&str>) ->
     }
 
     let env = make_envelope(
-        &format!("[bounty verify] {result}: '{oracle}' on branch '{branch}' (agent {agent_id}, task {task_id_short})"),
+        &format!(
+            "[bounty verify] {result}: '{oracle}' on branch '{branch}' (agent {agent_id}, task {task_id_short})"
+        ),
         None,
     );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
@@ -2094,7 +2328,8 @@ pub fn bounty_list(room_label: Option<&str>) -> Result<Vec<serde_json::Value>, S
     let room = resolve_room(room_label)?;
     let ts = now();
     let msgs = store::load_messages(&room.room_id, 604800);
-    let bounties: Vec<_> = msgs.into_iter()
+    let bounties: Vec<_> = msgs
+        .into_iter()
         .filter(|m| {
             if m["type"].as_str() != Some("bounty") || m["status"].as_str() != Some("open") {
                 return false;
@@ -2211,7 +2446,9 @@ fn verified_solana_deposit_from_tx(
     wallet: &str,
 ) -> Result<VerifiedSolanaDeposit, String> {
     if tx.is_null() {
-        return Err(format!("Transaction {signature} not found or not finalized yet."));
+        return Err(format!(
+            "Transaction {signature} not found or not finalized yet."
+        ));
     }
     if !tx["meta"]["err"].is_null() {
         return Err(format!("Transaction {signature} failed on-chain."));
@@ -2361,18 +2598,16 @@ fn payment_complete_solana_deposit(
 ///
 /// Requires env: STRIPE_SECRET_KEY
 /// Optional: STRIPE_SUCCESS_URL, STRIPE_CANCEL_URL
-pub fn payment_fund(
-    credits: i64,
-    room_label: Option<&str>,
-) -> Result<String, String> {
+pub fn payment_fund(credits: i64, room_label: Option<&str>) -> Result<String, String> {
     if credits <= 0 {
         return Err("Credits must be positive.".to_string());
     }
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
 
-    let stripe_key = std::env::var("STRIPE_SECRET_KEY")
-        .map_err(|_| "STRIPE_SECRET_KEY not set. Configure Stripe to enable payments.".to_string())?;
+    let stripe_key = std::env::var("STRIPE_SECRET_KEY").map_err(|_| {
+        "STRIPE_SECRET_KEY not set. Configure Stripe to enable payments.".to_string()
+    })?;
     if stripe_key.is_empty() {
         return Err("STRIPE_SECRET_KEY is empty.".to_string());
     }
@@ -2385,8 +2620,9 @@ pub fn payment_fund(
         ));
     }
 
-    let success_url = std::env::var("STRIPE_SUCCESS_URL")
-        .unwrap_or_else(|_| "https://theagora.dev/payment/success?session_id={CHECKOUT_SESSION_ID}".to_string());
+    let success_url = std::env::var("STRIPE_SUCCESS_URL").unwrap_or_else(|_| {
+        "https://theagora.dev/payment/success?session_id={CHECKOUT_SESSION_ID}".to_string()
+    });
     let cancel_url = std::env::var("STRIPE_CANCEL_URL")
         .unwrap_or_else(|_| "https://theagora.dev/payment/cancel".to_string());
 
@@ -2427,7 +2663,8 @@ pub fn payment_fund(
         .map_err(|e| format!("Stripe API error: {e}"))?;
 
     let status = resp.status().as_u16();
-    let body: serde_json::Value = resp.json()
+    let body: serde_json::Value = resp
+        .json()
         .map_err(|e| format!("Stripe response parse error: {e}"))?;
 
     if status != 200 {
@@ -2435,10 +2672,12 @@ pub fn payment_fund(
         return Err(format!("Stripe error {status}: {err}"));
     }
 
-    let session_id = body["id"].as_str()
+    let session_id = body["id"]
+        .as_str()
         .ok_or("Stripe response missing session id")?
         .to_string();
-    let checkout_url = body["url"].as_str()
+    let checkout_url = body["url"]
+        .as_str()
         .ok_or("Stripe response missing checkout url")?
         .to_string();
 
@@ -2491,8 +2730,9 @@ fn urlencoded(s: &str) -> String {
     let mut out = String::new();
     for b in s.bytes() {
         match b {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
-            | b'-' | b'_' | b'.' | b'~' => out.push(b as char),
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
             _ => out.push_str(&format!("%{:02X}", b)),
         }
     }
@@ -2502,16 +2742,15 @@ fn urlencoded(s: &str) -> String {
 /// Complete a deposit payment after Stripe webhook confirmation.
 /// Called by the webhook handler in serve.rs on `checkout.session.completed`.
 /// Mints credits to the agent's ledger and marks the payment completed.
-pub fn payment_complete_deposit(
-    stripe_session_id: &str,
-    room_id: &str,
-) -> Result<(), String> {
+pub fn payment_complete_deposit(stripe_session_id: &str, room_id: &str) -> Result<(), String> {
     let mut payments = store::load_payments();
     let record = payments
         .iter_mut()
-        .find(|p| p.stripe_id.as_deref() == Some(stripe_session_id)
-              && p.kind == store::PaymentKind::Deposit
-              && p.status == store::PaymentStatus::Pending)
+        .find(|p| {
+            p.stripe_id.as_deref() == Some(stripe_session_id)
+                && p.kind == store::PaymentKind::Deposit
+                && p.status == store::PaymentStatus::Pending
+        })
         .ok_or_else(|| format!("No pending deposit for session {stripe_session_id}"))?;
 
     record.status = store::PaymentStatus::Completed;
@@ -2524,11 +2763,21 @@ pub fn payment_complete_deposit(
     store::save_payments(&payments);
 
     // Mint net credits to agent (gross minus platform fee)
-    store::credit_add(room_id, &agent_id, net, &format!("stripe deposit {stripe_session_id} (net after 10% fee)"));
+    store::credit_add(
+        room_id,
+        &agent_id,
+        net,
+        &format!("stripe deposit {stripe_session_id} (net after 10% fee)"),
+    );
 
     // Collect platform fee to treasury
     let platform = "9d107f-cc"; // platform treasury agent
-    store::credit_add(room_id, platform, fee, &format!("platform fee 10% on deposit {stripe_session_id}"));
+    store::credit_add(
+        room_id,
+        platform,
+        fee,
+        &format!("platform fee 10% on deposit {stripe_session_id}"),
+    );
 
     Ok(())
 }
@@ -2536,10 +2785,7 @@ pub fn payment_complete_deposit(
 /// Request a credit withdrawal (credits → USD payout).
 /// Creates a pending withdrawal record. Actual payout requires admin approval
 /// and bank info on file — agora does not have Stripe Connect yet.
-pub fn payment_withdraw(
-    credits: i64,
-    room_label: Option<&str>,
-) -> Result<String, String> {
+pub fn payment_withdraw(credits: i64, room_label: Option<&str>) -> Result<String, String> {
     if credits <= 0 {
         return Err("Credits must be positive.".to_string());
     }
@@ -2548,7 +2794,9 @@ pub fn payment_withdraw(
 
     let balance = store::credit_balance(&room.room_id, &me);
     if balance < credits {
-        return Err(format!("Insufficient credits: have {balance}, need {credits}."));
+        return Err(format!(
+            "Insufficient credits: have {balance}, need {credits}."
+        ));
     }
 
     let amount_cents = credits / store::CREDITS_PER_USD_CENT;
@@ -2581,9 +2829,19 @@ pub fn payment_withdraw(
     };
 
     // Escrow the credits immediately (debit from agent)
-    store::credit_add(&room.room_id, &me, -credits, &format!("withdrawal escrow {}", &payment_id[..8]));
+    store::credit_add(
+        &room.room_id,
+        &me,
+        -credits,
+        &format!("withdrawal escrow {}", &payment_id[..8]),
+    );
     // Collect platform fee
-    store::credit_add(&room.room_id, "9d107f-cc", fee_credits, &format!("platform fee 10% on withdrawal {}", &payment_id[..8]));
+    store::credit_add(
+        &room.room_id,
+        "9d107f-cc",
+        fee_credits,
+        &format!("platform fee 10% on withdrawal {}", &payment_id[..8]),
+    );
 
     let mut payments = store::load_payments();
     payments.push(record);
@@ -2639,16 +2897,15 @@ fn infer_soma_subject_path(subject: &str) -> Option<String> {
 }
 
 fn current_git_head() -> Option<String> {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().ok()?;
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
     if !output.status.success() {
         return None;
     }
     let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if head.is_empty() {
-        None
-    } else {
-        Some(head)
-    }
+    if head.is_empty() { None } else { Some(head) }
 }
 
 fn git_churn_commits_since(git_ref: &str, path: &str) -> Option<u64> {
@@ -2748,7 +3005,13 @@ fn annotate_soma_message(msg: &mut serde_json::Value) {
     }
 }
 
-pub fn soma_assert(subject: &str, predicate: &str, confidence: Option<f64>, git_ref: Option<&str>, room_label: Option<&str>) -> Result<String, String> {
+pub fn soma_assert(
+    subject: &str,
+    predicate: &str,
+    confidence: Option<f64>,
+    git_ref: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
     let id = msg_id();
@@ -2778,14 +3041,25 @@ pub fn soma_assert(subject: &str, predicate: &str, confidence: Option<f64>, git_
     Ok(id)
 }
 
-pub fn soma_query(subject: &str, room_label: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+pub fn soma_query(
+    subject: &str,
+    room_label: Option<&str>,
+) -> Result<Vec<serde_json::Value>, String> {
     let room = resolve_room(room_label)?;
     let msgs = store::load_messages(&room.room_id, 604800);
     let q = subject.to_lowercase();
-    let mut beliefs: Vec<serde_json::Value> = msgs.into_iter().filter(|m| {
-        (m["type"].as_str() == Some("soma_belief") || m["type"].as_str() == Some("soma_correction")) &&
-        m["subject"].as_str().unwrap_or("").to_lowercase().contains(&q)
-    }).collect();
+    let mut beliefs: Vec<serde_json::Value> = msgs
+        .into_iter()
+        .filter(|m| {
+            (m["type"].as_str() == Some("soma_belief")
+                || m["type"].as_str() == Some("soma_correction"))
+                && m["subject"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_lowercase()
+                    .contains(&q)
+        })
+        .collect();
     for belief in &mut beliefs {
         annotate_soma_message(belief);
     }
@@ -2822,7 +3096,12 @@ fn resolve_soma_belief<'a>(
     }
 }
 
-pub fn soma_correct(belief_id: &str, new_predicate: &str, reason: Option<&str>, room_label: Option<&str>) -> Result<String, String> {
+pub fn soma_correct(
+    belief_id: &str,
+    new_predicate: &str,
+    reason: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
     let msgs = store::load_messages(&room.room_id, 604800);
@@ -2960,7 +3239,11 @@ pub fn task_add(title: &str, room_label: Option<&str>) -> Result<String, String>
 }
 
 /// Add a task to the room queue on behalf of a verified agent.
-pub fn task_add_as(agent_id: &str, title: &str, room_label: Option<&str>) -> Result<String, String> {
+pub fn task_add_as(
+    agent_id: &str,
+    title: &str,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let id = msg_id();
     let task = store::Task {
@@ -2983,7 +3266,11 @@ pub fn task_add_as(agent_id: &str, title: &str, room_label: Option<&str>) -> Res
     store::save_tasks(&room.room_id, &tasks);
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope_from(agent_id, &format!("[task] New: {title} (id: {})", &id[..6]), None);
+    let env = make_envelope_from(
+        agent_id,
+        &format!("[task] New: {title} (id: {})", &id[..6]),
+        None,
+    );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
@@ -3006,10 +3293,16 @@ pub fn task_claim(task_id: &str, room_label: Option<&str>) -> Result<String, Str
 }
 
 /// Claim an open task on behalf of a verified agent.
-pub fn task_claim_as(agent_id: &str, task_id: &str, room_label: Option<&str>) -> Result<String, String> {
+pub fn task_claim_as(
+    agent_id: &str,
+    task_id: &str,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let mut tasks = store::load_tasks(&room.room_id);
-    let task = tasks.iter_mut().find(|t| t.id.starts_with(task_id) && t.status == "open")
+    let task = tasks
+        .iter_mut()
+        .find(|t| t.id.starts_with(task_id) && t.status == "open")
         .ok_or_else(|| format!("No open task matching '{task_id}'"))?;
     task.status = "claimed".to_string();
     task.claimed_by = Some(agent_id.to_string());
@@ -3019,7 +3312,11 @@ pub fn task_claim_as(agent_id: &str, task_id: &str, room_label: Option<&str>) ->
     store::save_tasks(&room.room_id, &tasks);
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope_from(agent_id, &format!("[task] Claimed by {agent_id}: {title}"), None);
+    let env = make_envelope_from(
+        agent_id,
+        &format!("[task] Claimed by {agent_id}: {title}"),
+        None,
+    );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
@@ -3027,7 +3324,11 @@ pub fn task_claim_as(agent_id: &str, task_id: &str, room_label: Option<&str>) ->
 }
 
 /// Mark a task as done.
-pub fn task_done(task_id: &str, notes: Option<&str>, room_label: Option<&str>) -> Result<String, String> {
+pub fn task_done(
+    task_id: &str,
+    notes: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let me = store::get_agent_id();
     task_done_as(&me, task_id, notes, room_label)
 }
@@ -3041,11 +3342,15 @@ pub fn task_done_as(
 ) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let mut tasks = store::load_tasks(&room.room_id);
-    let task = tasks.iter_mut().find(|t| t.id.starts_with(task_id))
+    let task = tasks
+        .iter_mut()
+        .find(|t| t.id.starts_with(task_id))
         .ok_or_else(|| format!("No task matching '{task_id}'"))?;
     task.status = "done".to_string();
     task.updated_at = now();
-    if let Some(n) = notes { task.notes = Some(n.to_string()); }
+    if let Some(n) = notes {
+        task.notes = Some(n.to_string());
+    }
     let task_snapshot = task.clone();
     let title = task_snapshot.title.clone();
     let tid = task_snapshot.id.clone();
@@ -3053,7 +3358,11 @@ pub fn task_done_as(
 
     let note_str = notes.map(|n| format!(" — {n}")).unwrap_or_default();
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope_from(agent_id, &format!("[task] Done by {agent_id}: {title}{note_str}"), None);
+    let env = make_envelope_from(
+        agent_id,
+        &format!("[task] Done by {agent_id}: {title}{note_str}"),
+        None,
+    );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);
@@ -3070,7 +3379,11 @@ pub fn task_done_as(
 }
 
 /// Record partial progress on a task without marking it done.
-pub fn task_checkpoint(task_id: &str, notes: Option<&str>, room_label: Option<&str>) -> Result<String, String> {
+pub fn task_checkpoint(
+    task_id: &str,
+    notes: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let me = store::get_agent_id();
     task_checkpoint_as(&me, task_id, notes, room_label)
 }
@@ -3091,7 +3404,10 @@ pub fn task_checkpoint_as(
 
     if let Some(claimed_by) = task.claimed_by.as_deref() {
         if claimed_by != agent_id {
-            return Err(format!("Task '{}' is currently claimed by '{}'.", task.id, claimed_by));
+            return Err(format!(
+                "Task '{}' is currently claimed by '{}'.",
+                task.id, claimed_by
+            ));
         }
     } else {
         task.status = "claimed".to_string();
@@ -3102,7 +3418,9 @@ pub fn task_checkpoint_as(
     if let Some(note) = notes {
         task.notes = Some(note.to_string());
     }
-    let checkpoint_notes = notes.map(|note| note.to_string()).or_else(|| task.notes.clone());
+    let checkpoint_notes = notes
+        .map(|note| note.to_string())
+        .or_else(|| task.notes.clone());
     let task_snapshot = task.clone();
     let title = task_snapshot.title.clone();
     let tid = task_snapshot.id.clone();
@@ -3134,7 +3452,11 @@ pub fn task_checkpoint_as(
 }
 
 /// Reject a task and, if currently claimed by the rejecting agent, return it to the open pool.
-pub fn task_reject(task_id: &str, notes: Option<&str>, room_label: Option<&str>) -> Result<String, String> {
+pub fn task_reject(
+    task_id: &str,
+    notes: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let me = store::get_agent_id();
     task_reject_as(&me, task_id, notes, room_label)
 }
@@ -3155,7 +3477,10 @@ pub fn task_reject_as(
 
     if let Some(claimed_by) = task.claimed_by.as_deref() {
         if claimed_by != agent_id {
-            return Err(format!("Task '{}' is currently claimed by '{}'.", task.id, claimed_by));
+            return Err(format!(
+                "Task '{}' is currently claimed by '{}'.",
+                task.id, claimed_by
+            ));
         }
         task.status = "open".to_string();
         task.claimed_by = None;
@@ -3165,7 +3490,9 @@ pub fn task_reject_as(
     if let Some(note) = notes {
         task.notes = Some(note.to_string());
     }
-    let rejection_notes = notes.map(|note| note.to_string()).or_else(|| task.notes.clone());
+    let rejection_notes = notes
+        .map(|note| note.to_string())
+        .or_else(|| task.notes.clone());
     let task_snapshot = task.clone();
     let title = task_snapshot.title.clone();
     let tid = task_snapshot.id.clone();
@@ -3378,17 +3705,33 @@ pub fn seed_verify(seed_id: &str, answer: &str, room_label: Option<&str>) -> Res
         updated_at: now(),
         notes: Some(format!("difficulty:{}", seed_snapshot.difficulty)),
         acceptance_oracle: None,
-        reward_credits: if credit_reward > 0 { Some(credit_reward) } else { None },
+        reward_credits: if credit_reward > 0 {
+            Some(credit_reward)
+        } else {
+            None
+        },
         reward_trust: None,
         submissions: vec![],
         expires_at: None,
     };
 
-    publish_task_receipt(&room, &task, &me, "done", task.notes.as_deref(), task.updated_at);
+    publish_task_receipt(
+        &room,
+        &task,
+        &me,
+        "done",
+        task.notes.as_deref(),
+        task.updated_at,
+    );
 
     // Grant credits for medium/hard seeds (proof-of-work bootstrapping).
     if credit_reward > 0 {
-        store::credit_add(&room.room_id, &me, credit_reward, &format!("seed:{}", &seed_snapshot.id[..8]));
+        store::credit_add(
+            &room.room_id,
+            &me,
+            credit_reward,
+            &format!("seed:{}", &seed_snapshot.id[..8]),
+        );
     }
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
@@ -3454,7 +3797,10 @@ pub fn task_list(room_label: Option<&str>) -> Result<Vec<store::Task>, String> {
             if let Some(colon) = rest.find(": ") {
                 let claimer = &rest[..colon];
                 let title = &rest[colon + 2..];
-                if let Some(t) = tasks.iter_mut().find(|t| t.title == title && t.status == "open") {
+                if let Some(t) = tasks
+                    .iter_mut()
+                    .find(|t| t.title == title && t.status == "open")
+                {
                     t.status = "claimed".to_string();
                     t.claimed_by = Some(claimer.to_string());
                 }
@@ -3463,7 +3809,10 @@ pub fn task_list(room_label: Option<&str>) -> Result<Vec<store::Task>, String> {
             let rest = &text["[task] Done by ".len()..];
             if let Some(colon) = rest.find(": ") {
                 let title_and_notes = &rest[colon + 2..];
-                let title = title_and_notes.split(" — ").next().unwrap_or(title_and_notes);
+                let title = title_and_notes
+                    .split(" — ")
+                    .next()
+                    .unwrap_or(title_and_notes);
                 if let Some(t) = tasks.iter_mut().find(|t| t.title == title) {
                     t.status = "done".to_string();
                 }
@@ -3528,7 +3877,11 @@ pub fn timeline(since: &str, room_label: Option<&str>) -> Result<Vec<serde_json:
             "admin"
         } else if evt["text"].as_str().unwrap_or("").starts_with("Kicked ") {
             "kick"
-        } else if evt["text"].as_str().unwrap_or("").starts_with("[scheduled]") {
+        } else if evt["text"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("[scheduled]")
+        {
             "scheduled"
         } else {
             "message"
@@ -3548,7 +3901,10 @@ pub fn digest(since: &str, room_label: Option<&str>) -> Result<String, String> {
     let reactions = store::load_reactions(&room.room_id);
 
     if msgs.is_empty() {
-        return Ok(format!("# {} — Digest (last {})\n\nNo activity.", room.label, since));
+        return Ok(format!(
+            "# {} — Digest (last {})\n\nNo activity.",
+            room.label, since
+        ));
     }
 
     let mut agents: HashMap<String, u64> = HashMap::new();
@@ -3561,7 +3917,9 @@ pub fn digest(since: &str, room_label: Option<&str>) -> Result<String, String> {
         *agents.entry(from).or_insert(0) += 1;
         if let Some(text) = msg["text"].as_str() {
             for word in text.split_whitespace() {
-                let w = word.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase();
+                let w = word
+                    .trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_lowercase();
                 if w.len() >= 5 && !is_stopword(&w) {
                     *topics.entry(w).or_insert(0) += 1;
                 }
@@ -3578,13 +3936,20 @@ pub fn digest(since: &str, room_label: Option<&str>) -> Result<String, String> {
     let total_reactions: usize = reactions.values().map(|v| v.len()).sum();
 
     let first_dt = chrono::DateTime::from_timestamp(first_ts as i64, 0)
-        .map(|d| d.format("%H:%M").to_string()).unwrap_or_default();
+        .map(|d| d.format("%H:%M").to_string())
+        .unwrap_or_default();
     let last_dt = chrono::DateTime::from_timestamp(last_ts as i64, 0)
-        .map(|d| d.format("%H:%M").to_string()).unwrap_or_default();
+        .map(|d| d.format("%H:%M").to_string())
+        .unwrap_or_default();
 
     let mut report = format!("# {} — Digest (last {})\n\n", room.label, since);
     report.push_str(&format!("**Period:** {} → {}\n", first_dt, last_dt));
-    report.push_str(&format!("**Messages:** {}  |  **Agents:** {}  |  **Reactions:** {}\n\n", msgs.len(), sorted_agents.len(), total_reactions));
+    report.push_str(&format!(
+        "**Messages:** {}  |  **Agents:** {}  |  **Reactions:** {}\n\n",
+        msgs.len(),
+        sorted_agents.len(),
+        total_reactions
+    ));
 
     report.push_str("## Participants\n");
     for (agent, count) in &sorted_agents {
@@ -3592,7 +3957,13 @@ pub fn digest(since: &str, room_label: Option<&str>) -> Result<String, String> {
     }
 
     report.push_str("\n## Key Topics\n");
-    report.push_str(&sorted_topics.iter().map(|(w, _)| w.as_str()).collect::<Vec<_>>().join(", "));
+    report.push_str(
+        &sorted_topics
+            .iter()
+            .map(|(w, _)| w.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
 
     report.push_str("\n\n## Highlights\n");
     // Pick messages with most text (likely substantive)
@@ -3647,7 +4018,8 @@ fn fire_webhooks(room_id: &str, msgs: &[serde_json::Value]) {
             "messages": msgs,
             "count": msgs.len(),
         });
-        let _ = client.post(&hook.url)
+        let _ = client
+            .post(&hook.url)
             .header("Content-Type", "application/json")
             .body(serde_json::to_string(&payload).unwrap())
             .send();
@@ -3655,14 +4027,19 @@ fn fire_webhooks(room_id: &str, msgs: &[serde_json::Value]) {
 }
 
 /// Find messages where an agent was @mentioned.
-pub fn mentions(agent_id: Option<&str>, since: &str, room_label: Option<&str>) -> Result<Vec<serde_json::Value>, String> {
+pub fn mentions(
+    agent_id: Option<&str>,
+    since: &str,
+    room_label: Option<&str>,
+) -> Result<Vec<serde_json::Value>, String> {
     let room = resolve_room(room_label)?;
     let target = agent_id.unwrap_or(&store::get_agent_id()).to_string();
     let since_secs = parse_since(since);
     let msgs = store::load_messages(&room.room_id, since_secs);
     let pattern = format!("@{target}");
 
-    let results: Vec<serde_json::Value> = msgs.into_iter()
+    let results: Vec<serde_json::Value> = msgs
+        .into_iter()
         .filter(|m| {
             let text = m["text"].as_str().unwrap_or("");
             let from = m["from"].as_str().unwrap_or("");
@@ -3707,7 +4084,9 @@ pub fn encrypt_data(data: &[u8], room_label: Option<&str>) -> Result<String, Str
 pub fn decrypt_data(b64: &str, room_label: Option<&str>) -> Result<Vec<u8>, String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let blob = BASE64.decode(b64).map_err(|e| format!("Decode failed: {e}"))?;
+    let blob = BASE64
+        .decode(b64)
+        .map_err(|e| format!("Decode failed: {e}"))?;
     crypto::decrypt(&blob, &room_key, room.room_id.as_bytes())
         .map_err(|e| format!("Decrypt failed: {e}"))
 }
@@ -3719,10 +4098,13 @@ pub fn changelog(since: &str, room_label: Option<&str>) -> Result<Vec<serde_json
     let since_secs = parse_since(since);
     let msgs = store::load_messages(&room.room_id, since_secs);
 
-    let keywords = ["shipped", "merged", "built", "added", "fixed", "PR #", "pr #",
-        "feature", "released", "deployed", "launched", "done", "complete"];
+    let keywords = [
+        "shipped", "merged", "built", "added", "fixed", "PR #", "pr #", "feature", "released",
+        "deployed", "launched", "done", "complete",
+    ];
 
-    let results: Vec<serde_json::Value> = msgs.into_iter()
+    let results: Vec<serde_json::Value> = msgs
+        .into_iter()
         .filter(|m| {
             let text = m["text"].as_str().unwrap_or("").to_lowercase();
             keywords.iter().any(|kw| text.contains(&kw.to_lowercase()))
@@ -3742,7 +4124,11 @@ pub fn healthcheck(room_label: Option<&str>) -> Result<Vec<(String, bool, String
 
     // Check rooms
     let rooms = store::load_registry();
-    checks.push(("Rooms joined".into(), !rooms.is_empty(), format!("{}", rooms.len())));
+    checks.push((
+        "Rooms joined".into(),
+        !rooms.is_empty(),
+        format!("{}", rooms.len()),
+    ));
 
     // Check active room
     let active = if let Some(r) = room_label {
@@ -3758,13 +4144,19 @@ pub fn healthcheck(room_label: Option<&str>) -> Result<Vec<(String, bool, String
             let room_key = crypto::derive_room_key(&r.secret, &r.room_id);
             let test_data = b"healthcheck";
             match crypto::encrypt(test_data, &room_key, b"test") {
-                Ok(blob) => {
-                    match crypto::decrypt(&blob, &room_key, b"test") {
-                        Ok(pt) => checks.push(("AES-256-GCM".into(), pt == test_data, "encrypt/decrypt OK".into())),
-                        Err(e) => checks.push(("AES-256-GCM".into(), false, format!("decrypt failed: {e}"))),
+                Ok(blob) => match crypto::decrypt(&blob, &room_key, b"test") {
+                    Ok(pt) => checks.push((
+                        "AES-256-GCM".into(),
+                        pt == test_data,
+                        "encrypt/decrypt OK".into(),
+                    )),
+                    Err(e) => {
+                        checks.push(("AES-256-GCM".into(), false, format!("decrypt failed: {e}")))
                     }
+                },
+                Err(e) => {
+                    checks.push(("AES-256-GCM".into(), false, format!("encrypt failed: {e}")))
                 }
-                Err(e) => checks.push(("AES-256-GCM".into(), false, format!("encrypt failed: {e}"))),
             }
 
             // Check relay connectivity
@@ -3777,10 +4169,18 @@ pub fn healthcheck(room_label: Option<&str>) -> Result<Vec<(String, bool, String
 
             // Check messages
             let msgs = store::load_messages(&r.room_id, 3600);
-            checks.push(("Local messages".into(), true, format!("{} in last 1h", msgs.len())));
+            checks.push((
+                "Local messages".into(),
+                true,
+                format!("{} in last 1h", msgs.len()),
+            ));
 
             // Check members
-            checks.push(("Members tracked".into(), !r.members.is_empty(), format!("{}", r.members.len())));
+            checks.push((
+                "Members tracked".into(),
+                !r.members.is_empty(),
+                format!("{}", r.members.len()),
+            ));
         }
         None => {
             checks.push(("Active room".into(), false, "none".into()));
@@ -3792,7 +4192,11 @@ pub fn healthcheck(room_label: Option<&str>) -> Result<Vec<(String, bool, String
 
 /// Schedule a message for future delivery.
 /// Stores in a queue file; `check` or `send-scheduled` delivers when time is up.
-pub fn schedule_message(text: &str, deliver_at: u64, room_label: Option<&str>) -> Result<String, String> {
+pub fn schedule_message(
+    text: &str,
+    deliver_at: u64,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let id = msg_id();
     let entry = json!({
@@ -3890,10 +4294,12 @@ pub fn compact(keep_hours: u64, room_label: Option<&str>) -> Result<(usize, usiz
 pub fn grep(query: &str, use_regex: bool) -> Result<Vec<(String, serde_json::Value)>, String> {
     let rooms = store::load_registry();
     let re = if use_regex {
-        Some(regex::RegexBuilder::new(query)
-            .case_insensitive(true)
-            .build()
-            .map_err(|e| format!("Invalid regex: {e}"))?)
+        Some(
+            regex::RegexBuilder::new(query)
+                .case_insensitive(true)
+                .build()
+                .map_err(|e| format!("Invalid regex: {e}"))?,
+        )
     } else {
         None
     };
@@ -3988,7 +4394,11 @@ pub fn stats(room_label: Option<&str>) -> Result<serde_json::Value, String> {
 }
 
 /// Export room history as JSON.
-pub fn export(since: &str, out_path: Option<&str>, room_label: Option<&str>) -> Result<(String, usize), String> {
+pub fn export(
+    since: &str,
+    out_path: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<(String, usize), String> {
     let room = resolve_room(room_label)?;
     let since_secs = parse_since(since);
     let msgs = store::load_messages(&room.room_id, since_secs);
@@ -4036,13 +4446,17 @@ pub fn info(room_label: Option<&str>) -> Result<serde_json::Value, String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
     let msgs = store::load_messages(&room.room_id, 7200);
-    let members: Vec<_> = room.members.iter().map(|m| {
-        json!({
-            "agent_id": m.agent_id,
-            "role": format!("{:?}", m.role),
-            "nickname": m.nickname,
+    let members: Vec<_> = room
+        .members
+        .iter()
+        .map(|m| {
+            json!({
+                "agent_id": m.agent_id,
+                "role": format!("{:?}", m.role),
+                "nickname": m.nickname,
+            })
         })
-    }).collect();
+        .collect();
     Ok(json!({
         "room_id": room.room_id,
         "label": room.label,
@@ -4060,7 +4474,11 @@ pub fn who(room_label: Option<&str>, online_only: bool) -> Result<Vec<store::Roo
     let room = resolve_room(room_label)?;
     if online_only {
         let cutoff = now() - 300; // 5 minutes
-        Ok(room.members.into_iter().filter(|m| m.last_seen >= cutoff).collect())
+        Ok(room
+            .members
+            .into_iter()
+            .filter(|m| m.last_seen >= cutoff)
+            .collect())
     } else {
         Ok(room.members)
     }
@@ -4142,7 +4560,11 @@ fn send_watch_heartbeat(room_id: &str) -> Result<(), String> {
 /// Watch a room in real-time. Calls `on_message` for each new message.
 /// Sends a heartbeat every `heartbeat_secs` seconds.
 /// Blocks forever.
-pub fn watch<F>(room_label: Option<&str>, heartbeat_secs: u64, mut on_message: F) -> Result<(), String>
+pub fn watch<F>(
+    room_label: Option<&str>,
+    heartbeat_secs: u64,
+    mut on_message: F,
+) -> Result<(), String>
 where
     F: FnMut(&serde_json::Value),
 {
@@ -4216,7 +4638,9 @@ pub fn recap(since: &str, room_label: Option<&str>) -> Result<serde_json::Value,
         // Extract keywords (words 4+ chars, skip common ones)
         if let Some(text) = msg["text"].as_str() {
             for word in text.split_whitespace() {
-                let w = word.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase();
+                let w = word
+                    .trim_matches(|c: char| !c.is_alphanumeric())
+                    .to_lowercase();
                 if w.len() >= 4 && !is_stopword(&w) {
                     *words.entry(w).or_insert(0) += 1;
                 }
@@ -4247,22 +4671,79 @@ pub fn recap(since: &str, room_label: Option<&str>) -> Result<serde_json::Value,
 }
 
 fn is_stopword(w: &str) -> bool {
-    matches!(w, "that" | "this" | "with" | "from" | "have" | "been"
-        | "will" | "your" | "they" | "what" | "when" | "were" | "them"
-        | "then" | "than" | "each" | "just" | "also" | "into" | "some"
-        | "more" | "here" | "agora" | "room" | "send" | "read" | "check"
-        | "should" | "would" | "could" | "about" | "there" | "which"
-        | "their" | "after" | "before" | "still" | "already" | "need"
-        | "want" | "like" | "make" | "does" | "done" | "good" | "work"
-        | "working" | "works" | "built" | "build" | "main" | "branch"
-        | "push" | "pull" | "merge" | "merged")
+    matches!(
+        w,
+        "that"
+            | "this"
+            | "with"
+            | "from"
+            | "have"
+            | "been"
+            | "will"
+            | "your"
+            | "they"
+            | "what"
+            | "when"
+            | "were"
+            | "them"
+            | "then"
+            | "than"
+            | "each"
+            | "just"
+            | "also"
+            | "into"
+            | "some"
+            | "more"
+            | "here"
+            | "agora"
+            | "room"
+            | "send"
+            | "read"
+            | "check"
+            | "should"
+            | "would"
+            | "could"
+            | "about"
+            | "there"
+            | "which"
+            | "their"
+            | "after"
+            | "before"
+            | "still"
+            | "already"
+            | "need"
+            | "want"
+            | "like"
+            | "make"
+            | "does"
+            | "done"
+            | "good"
+            | "work"
+            | "working"
+            | "works"
+            | "built"
+            | "build"
+            | "main"
+            | "branch"
+            | "push"
+            | "pull"
+            | "merge"
+            | "merged"
+    )
 }
 
 // ── File Sharing ───────────────────────────────────────────────
 
 const MAX_INLINE_FILE_SIZE: usize = 32 * 1024; // 32KB
 
-fn make_file_envelope(filename: &str, file_id: &str, data: &str, size: u64, chunk_n: u64, total_chunks: u64) -> serde_json::Value {
+fn make_file_envelope(
+    filename: &str,
+    file_id: &str,
+    data: &str,
+    size: u64,
+    chunk_n: u64,
+    total_chunks: u64,
+) -> serde_json::Value {
     json!({
         "v": VERSION,
         "id": msg_id(),
@@ -4342,7 +4823,11 @@ pub fn list_files(room_label: Option<&str>) -> Result<Vec<serde_json::Value>, St
 }
 
 /// Download a file from the room by file_id.
-pub fn download_file(file_id: &str, out_path: Option<&str>, room_label: Option<&str>) -> Result<String, String> {
+pub fn download_file(
+    file_id: &str,
+    out_path: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<String, String> {
     let room = resolve_room(room_label)?;
     let msgs = store::load_messages(&room.room_id, 604800);
 
@@ -4370,14 +4855,20 @@ pub fn download_file(file_id: &str, out_path: Option<&str>, room_label: Option<&
         return Err(format!("File '{file_id}' not found."));
     }
     if chunks.len() as u64 != total_chunks {
-        return Err(format!("Incomplete file: got {}/{} chunks.", chunks.len(), total_chunks));
+        return Err(format!(
+            "Incomplete file: got {}/{} chunks.",
+            chunks.len(),
+            total_chunks
+        ));
     }
 
     // Sort by chunk number and reassemble
     chunks.sort_by_key(|(n, _)| *n);
     let mut file_data = Vec::new();
     for (_, data) in &chunks {
-        let decoded = BASE64.decode(data).map_err(|e| format!("Decode error: {e}"))?;
+        let decoded = BASE64
+            .decode(data)
+            .map_err(|e| format!("Decode error: {e}"))?;
         file_data.extend_from_slice(&decoded);
     }
 
@@ -4389,27 +4880,24 @@ pub fn download_file(file_id: &str, out_path: Option<&str>, room_label: Option<&
 
 #[cfg(test)]
 mod tests {
-    use base64::Engine;
     use super::{
-        allow_incoming_message, annotate_soma_message, count_invite_redemptions_in_envs,
-        decrypt_payload, discover, discovery_decay_weight, enforce_outbound_plaza_rate_limit,
-        encrypt_envelope,
-        infer_soma_subject_path, ingest_auxiliary_event, list_role_leases, list_work_receipts,
-        make_envelope, make_invite_redemption, pin, pins, resolve_room, role_claim,
-        role_heartbeat, role_release, payment_complete_solana_deposit,
-        seed_gen, seed_plaza_rate_limit_state, seed_verify, send_watch_heartbeat,
-        should_display_message, signing_message_bytes, soma_churn_decay, soma_correct,
-        bounty_expire_check, bounty_post, bounty_submit, bounty_verify, stale_claim_weight,
-        task_add, task_add_as, task_add_with_oracle, task_checkpoint_as, task_claim_as,
-        task_done_as, task_reject_as,
-        task_checkpoint, task_done, unpin,
-        verified_solana_deposit_from_tx, SignedWirePayload, VerifiedSolanaDeposit,
-        SIGNED_WIRE_VERSION, BASE64, DISCOVERY_POSITIVE_HALF_LIFE_SECS,
-        PLAZA_RATE_LIMIT_WINDOW_SECS, SOLANA_TOKEN_PROGRAM, SOLANA_TREASURY_WALLET,
-        SOLANA_USDC_MINT,
+        BASE64, DISCOVERY_POSITIVE_HALF_LIFE_SECS, PLAZA_RATE_LIMIT_WINDOW_SECS,
+        SIGNED_WIRE_VERSION, SOLANA_TOKEN_PROGRAM, SOLANA_TREASURY_WALLET, SOLANA_USDC_MINT,
+        SignedWirePayload, VerifiedSolanaDeposit, allow_incoming_message, annotate_soma_message,
+        bounty_expire_check, bounty_post, bounty_submit, bounty_verify,
+        count_invite_redemptions_in_envs, decrypt_payload, discover, discovery_decay_weight,
+        encrypt_envelope, enforce_outbound_plaza_rate_limit, infer_soma_subject_path,
+        ingest_auxiliary_event, list_role_leases, list_work_receipts, make_envelope,
+        make_invite_redemption, payment_complete_solana_deposit, pin, pins, resolve_room,
+        role_claim, role_heartbeat, role_release, seed_gen, seed_plaza_rate_limit_state,
+        seed_verify, send_watch_heartbeat, should_display_message, signing_message_bytes,
+        soma_churn_decay, soma_correct, stale_claim_weight, task_add, task_add_as,
+        task_add_with_oracle, task_checkpoint, task_checkpoint_as, task_claim_as, task_done,
+        task_done_as, task_reject_as, unpin, verified_solana_deposit_from_tx,
     };
     use crate::crypto;
     use crate::store::{self, Role};
+    use base64::Engine;
     use serde_json::json;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -4451,20 +4939,26 @@ mod tests {
         let first = "aaaabbbb".to_string();
         let second = "ccccdddd".to_string();
 
-        store::save_message(&room.room_id, &json!({
-            "id": first,
-            "from": "pin-test",
-            "ts": 100,
-            "text": "first",
-            "v": "3.0",
-        }));
-        store::save_message(&room.room_id, &json!({
-            "id": second,
-            "from": "pin-test",
-            "ts": 101,
-            "text": "second",
-            "v": "3.0",
-        }));
+        store::save_message(
+            &room.room_id,
+            &json!({
+                "id": first,
+                "from": "pin-test",
+                "ts": 100,
+                "text": "first",
+                "v": "3.0",
+            }),
+        );
+        store::save_message(
+            &room.room_id,
+            &json!({
+                "id": second,
+                "from": "pin-test",
+                "ts": 101,
+                "text": "second",
+                "v": "3.0",
+            }),
+        );
 
         (home, first, second)
     }
@@ -4608,13 +5102,16 @@ mod tests {
         let now_ts = current_ts();
 
         for i in 0..10 {
-            store::save_message(&room.room_id, &json!({
-                "id": format!("spam{i}"),
-                "from": "spammer",
-                "ts": now_ts - 30 + i,
-                "text": format!("msg {i}"),
-                "v": "3.0",
-            }));
+            store::save_message(
+                &room.room_id,
+                &json!({
+                    "id": format!("spam{i}"),
+                    "from": "spammer",
+                    "ts": now_ts - 30 + i,
+                    "text": format!("msg {i}"),
+                    "v": "3.0",
+                }),
+            );
         }
 
         let recent = store::load_messages(&room.room_id, PLAZA_RATE_LIMIT_WINDOW_SECS);
@@ -4627,7 +5124,9 @@ mod tests {
             "v": "3.0",
         });
 
-        assert!(!allow_incoming_message(&room, &overflow, now_ts, &mut state));
+        assert!(!allow_incoming_message(
+            &room, &overflow, now_ts, &mut state
+        ));
         assert!(store::load_muted(&room.room_id).contains("spammer"));
     }
 
@@ -4638,13 +5137,16 @@ mod tests {
         let now_ts = current_ts();
 
         for i in 0..10 {
-            store::save_message(&room.room_id, &json!({
-                "id": format!("mine{i}"),
-                "from": "speaker",
-                "ts": now_ts - 30 + i,
-                "text": format!("own {i}"),
-                "v": "3.0",
-            }));
+            store::save_message(
+                &room.room_id,
+                &json!({
+                    "id": format!("mine{i}"),
+                    "from": "speaker",
+                    "ts": now_ts - 30 + i,
+                    "text": format!("own {i}"),
+                    "v": "3.0",
+                }),
+            );
         }
 
         let err = enforce_outbound_plaza_rate_limit(&room, "speaker").unwrap_err();
@@ -4806,7 +5308,10 @@ mod tests {
         let payments = store::load_payments();
         assert_eq!(payments.len(), 1);
         assert_eq!(payments[0].stripe_id.as_deref(), Some("solsig123"));
-        assert!(matches!(payments[0].provider, store::PaymentProvider::Solana));
+        assert!(matches!(
+            payments[0].provider,
+            store::PaymentProvider::Solana
+        ));
 
         let dup = payment_complete_solana_deposit(&verified, Some("plaza")).unwrap_err();
         assert!(dup.contains("already claimed"));
@@ -4858,7 +5363,10 @@ mod tests {
             role_heartbeat("backend", Some("Owns transport too"), 1200, Some("plaza")).unwrap();
         assert!(heartbeat.lease_expires >= claimed.lease_expires);
         let stored = store::get_role_lease(&room.room_id, "backend").unwrap();
-        assert_eq!(stored.context_summary.as_deref(), Some("Owns transport too"));
+        assert_eq!(
+            stored.context_summary.as_deref(),
+            Some("Owns transport too")
+        );
 
         role_release("backend", Some("plaza")).unwrap();
         assert!(store::get_role_lease(&room.room_id, "backend").is_none());
@@ -4980,21 +5488,28 @@ mod tests {
         let _guard = store::test_env_lock().lock().unwrap();
         let (_home, room) = setup_soma_room();
         let belief_id = "abcd1234".to_string();
-        store::save_message(&room.room_id, &json!({
-            "id": belief_id,
-            "from": "soma-test",
-            "ts": current_ts(),
-            "type": "soma_belief",
-            "subject": "src/chat.rs:soma_correct",
-            "predicate": "returns success for unknown belief ids",
-            "confidence": 0.7,
-            "v": "3.0",
-            "text": "[soma] src/chat.rs:soma_correct: returns success for unknown belief ids",
-        }));
+        store::save_message(
+            &room.room_id,
+            &json!({
+                "id": belief_id,
+                "from": "soma-test",
+                "ts": current_ts(),
+                "type": "soma_belief",
+                "subject": "src/chat.rs:soma_correct",
+                "predicate": "returns success for unknown belief ids",
+                "confidence": 0.7,
+                "v": "3.0",
+                "text": "[soma] src/chat.rs:soma_correct: returns success for unknown belief ids",
+            }),
+        );
 
-        let correction_id =
-            soma_correct("abcd", "rejects unknown belief ids", Some("regression fix"), None)
-                .unwrap();
+        let correction_id = soma_correct(
+            "abcd",
+            "rejects unknown belief ids",
+            Some("regression fix"),
+            None,
+        )
+        .unwrap();
         let msgs = store::load_messages(&room.room_id, u64::MAX);
         let correction = msgs
             .iter()
@@ -5024,17 +5539,20 @@ mod tests {
         let (_home, room) = setup_soma_room();
         let base_ts = current_ts();
         for (id, ts) in [("abcd1111", base_ts), ("abcd2222", base_ts + 1)] {
-            store::save_message(&room.room_id, &json!({
-                "id": id,
-                "from": "soma-test",
-                "ts": ts,
-                "type": "soma_belief",
-                "subject": "src/main.rs",
-                "predicate": "placeholder",
-                "confidence": 0.6,
-                "v": "3.0",
-                "text": "[soma] src/main.rs: placeholder",
-            }));
+            store::save_message(
+                &room.room_id,
+                &json!({
+                    "id": id,
+                    "from": "soma-test",
+                    "ts": ts,
+                    "type": "soma_belief",
+                    "subject": "src/main.rs",
+                    "predicate": "placeholder",
+                    "confidence": 0.6,
+                    "v": "3.0",
+                    "text": "[soma] src/main.rs: placeholder",
+                }),
+            );
         }
 
         let err = soma_correct("abcd", "new predicate", Some("ambiguous"), None).unwrap_err();
@@ -5073,21 +5591,41 @@ mod tests {
         std::fs::create_dir_all(&repo).unwrap();
 
         assert!(run_git(&repo, &["init"]).status.success());
-        assert!(run_git(&repo, &["config", "user.email", "soma@test.local"]).status.success());
-        assert!(run_git(&repo, &["config", "user.name", "Soma Test"]).status.success());
-        assert!(run_git(&repo, &["config", "commit.gpgsign", "false"]).status.success());
+        assert!(
+            run_git(&repo, &["config", "user.email", "soma@test.local"])
+                .status
+                .success()
+        );
+        assert!(
+            run_git(&repo, &["config", "user.name", "Soma Test"])
+                .status
+                .success()
+        );
+        assert!(
+            run_git(&repo, &["config", "commit.gpgsign", "false"])
+                .status
+                .success()
+        );
 
         let tracked = repo.join("tracked.txt");
         std::fs::write(&tracked, "v1\n").unwrap();
         assert!(run_git(&repo, &["add", "tracked.txt"]).status.success());
-        assert!(run_git(&repo, &["commit", "-m", "initial"]).status.success());
+        assert!(
+            run_git(&repo, &["commit", "-m", "initial"])
+                .status
+                .success()
+        );
 
         let base_ref = String::from_utf8_lossy(&run_git(&repo, &["rev-parse", "HEAD"]).stdout)
             .trim()
             .to_string();
 
         std::fs::write(&tracked, "v2\n").unwrap();
-        assert!(run_git(&repo, &["commit", "-am", "second"]).status.success());
+        assert!(
+            run_git(&repo, &["commit", "-am", "second"])
+                .status
+                .success()
+        );
         std::fs::write(&tracked, "v3\n").unwrap();
         assert!(run_git(&repo, &["commit", "-am", "third"]).status.success());
 
@@ -5164,7 +5702,12 @@ mod tests {
             std::env::set_var("AGORA_AGENT_ID", "alice");
         }
 
-        let room = store::add_room("ag-sign-mismatch", "secret-sign-mismatch", "sign-mismatch", Role::Admin);
+        let room = store::add_room(
+            "ag-sign-mismatch",
+            "secret-sign-mismatch",
+            "sign-mismatch",
+            Role::Admin,
+        );
         let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
 
         let trusted_env = make_envelope("trusted", None);
@@ -5180,7 +5723,8 @@ mod tests {
         });
         let plaintext = serde_json::to_string(&forged_env).unwrap();
         let (enc_key, _) = crypto::derive_message_keys(&room_key);
-        let blob = crypto::encrypt(plaintext.as_bytes(), &enc_key, room.room_id.as_bytes()).unwrap();
+        let blob =
+            crypto::encrypt(plaintext.as_bytes(), &enc_key, room.room_id.as_bytes()).unwrap();
         let payload = BASE64.encode(&blob);
 
         let alt_pkcs8 = crypto::generate_signing_keypair_pkcs8().unwrap();
@@ -5193,17 +5737,23 @@ mod tests {
             payload,
             signing_pubkey: alt_pubkey,
             sig,
-        }).unwrap();
+        })
+        .unwrap();
 
         let warning = decrypt_payload(&forged_wire, &room_key, &room.room_id).unwrap();
         assert_eq!(warning["type"].as_str(), Some("auth_warning"));
         assert_eq!(warning["from"].as_str(), Some("[auth]"));
         assert_eq!(warning["sender"].as_str(), Some("alice"));
-        assert_eq!(warning["auth_reason"].as_str(), Some("signing_key_mismatch"));
-        assert!(warning["text"]
-            .as_str()
-            .unwrap_or("")
-            .contains("signing key"));
+        assert_eq!(
+            warning["auth_reason"].as_str(),
+            Some("signing_key_mismatch")
+        );
+        assert!(
+            warning["text"]
+                .as_str()
+                .unwrap_or("")
+                .contains("signing key")
+        );
     }
 
     #[test]
@@ -5237,15 +5787,9 @@ mod tests {
         let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", &branch]);
 
         // Create a bounty task with a 50-credit reward. Oracle is "true" — always passes.
-        let task_id = task_add_with_oracle(
-            "Build feature X",
-            Some("true"),
-            Some(50),
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+        let task_id =
+            task_add_with_oracle("Build feature X", Some("true"), Some(50), None, None, None)
+                .unwrap();
 
         // Register a submission from the winner agent using the branch above.
         let mut tasks = store::load_tasks(&room.room_id);
@@ -5266,8 +5810,7 @@ mod tests {
         );
 
         // Run the oracle.
-        let result = bounty_verify(&task_id, agent_id, None)
-            .expect("bounty_verify should succeed");
+        let result = bounty_verify(&task_id, agent_id, None).expect("bounty_verify should succeed");
         assert!(
             result.starts_with("PASS"),
             "oracle 'true' must PASS, got: {result}"
@@ -5283,7 +5826,10 @@ mod tests {
         // Task should be closed and attributed to the winner.
         let tasks = store::load_tasks(&room.room_id);
         let task = tasks.iter().find(|t| t.id == task_id).unwrap();
-        assert_eq!(task.status, "done", "task must be marked done after oracle PASS");
+        assert_eq!(
+            task.status, "done",
+            "task must be marked done after oracle PASS"
+        );
         assert_eq!(
             task.claimed_by.as_deref(),
             Some(agent_id),
@@ -5291,7 +5837,10 @@ mod tests {
         );
 
         // Clean up the temporary branch.
-        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", "-D", &branch]);
+        let _ = run_git(
+            Path::new(env!("CARGO_MANIFEST_DIR")),
+            &["branch", "-D", &branch],
+        );
     }
 
     #[test]
@@ -5336,8 +5885,12 @@ mod tests {
         let task_id = task.id.clone();
         store::save_tasks(&room.room_id, &tasks);
 
-        let result = bounty_verify(&task_id, winner_id, None).expect("bounty_verify should succeed");
-        assert!(result.starts_with("PASS"), "oracle 'true' must PASS, got: {result}");
+        let result =
+            bounty_verify(&task_id, winner_id, None).expect("bounty_verify should succeed");
+        assert!(
+            result.starts_with("PASS"),
+            "oracle 'true' must PASS, got: {result}"
+        );
 
         assert_eq!(
             store::credit_balance(&room.room_id, winner_id),
@@ -5350,7 +5903,10 @@ mod tests {
             "poster retains remaining credits after bounty payout"
         );
 
-        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", "-D", &branch]);
+        let _ = run_git(
+            Path::new(env!("CARGO_MANIFEST_DIR")),
+            &["branch", "-D", &branch],
+        );
     }
 
     #[test]
@@ -5362,7 +5918,10 @@ mod tests {
         seed_agent_trust(&room.room_id, poster_id);
 
         let result = bounty_post("No-funds bounty", 1, Some("true"), Some(50), None, None);
-        assert!(result.is_err(), "bounty_post must reject insufficient credits");
+        assert!(
+            result.is_err(),
+            "bounty_post must reject insufficient credits"
+        );
         let err = result.unwrap_err();
         assert!(
             err.contains("Insufficient credits"),
@@ -5411,7 +5970,10 @@ mod tests {
 
         let result =
             bounty_verify(&task_id, submitter_id, None).expect("bounty_verify should report FAIL");
-        assert!(result.starts_with("FAIL"), "oracle 'false' must FAIL, got: {result}");
+        assert!(
+            result.starts_with("FAIL"),
+            "oracle 'false' must FAIL, got: {result}"
+        );
 
         assert_eq!(
             store::credit_balance(&room.room_id, submitter_id),
@@ -5424,7 +5986,10 @@ mod tests {
             "poster escrow must be refunded on FAIL"
         );
 
-        let _ = run_git(Path::new(env!("CARGO_MANIFEST_DIR")), &["branch", "-D", &branch]);
+        let _ = run_git(
+            Path::new(env!("CARGO_MANIFEST_DIR")),
+            &["branch", "-D", &branch],
+        );
     }
 
     /// Verify that a bounty poster cannot submit to their own bounty (anti-self-dealing).
@@ -5435,7 +6000,8 @@ mod tests {
         let (_home, room) = setup_plaza_room(poster_id, Role::Admin);
 
         // Poster creates a task directly (simulating bounty_post).
-        let task_id = task_add_with_oracle("Self-deal test task", None, Some(50), None, None, None).unwrap();
+        let task_id =
+            task_add_with_oracle("Self-deal test task", None, Some(50), None, None, None).unwrap();
 
         // The poster tries to submit to their own bounty.
         let result = bounty_submit(&task_id, "some-branch", None);
@@ -5464,18 +6030,15 @@ mod tests {
         let submitter_id = "bounty-expired-submit-worker";
         let (_home, room) = setup_plaza_room(submitter_id, Role::Admin);
 
-        let task_id = task_add_with_oracle(
-            "Expired submit bounty",
-            None,
-            Some(20),
-            None,
-            Some(1),
-            None,
-        )
-        .expect("task should exist");
+        let task_id =
+            task_add_with_oracle("Expired submit bounty", None, Some(20), None, Some(1), None)
+                .expect("task should exist");
 
         let mut tasks = store::load_tasks(&room.room_id);
-        let task = tasks.iter_mut().find(|t| t.id == task_id).expect("task exists");
+        let task = tasks
+            .iter_mut()
+            .find(|t| t.id == task_id)
+            .expect("task exists");
         task.status = "expired".to_string();
         store::save_tasks(&room.room_id, &tasks);
 
@@ -5507,7 +6070,10 @@ mod tests {
         .expect("task should exist");
 
         let mut tasks = store::load_tasks(&room.room_id);
-        let task = tasks.iter_mut().find(|t| t.id == task_id).expect("task exists");
+        let task = tasks
+            .iter_mut()
+            .find(|t| t.id == task_id)
+            .expect("task exists");
         task.status = "expired".to_string();
         task.submissions.push(store::BountySubmission {
             agent_id: submitter_id.to_string(),
@@ -5540,9 +6106,19 @@ mod tests {
             assert!(row["rank"].is_u64(), "rank must be an integer");
             assert!(row["agent_id"].is_string(), "agent_id must be a string");
             assert!(row["display"].is_string(), "display must be a string");
-            assert!(row["credits"].is_i64() || row["credits"].is_u64(), "credits must be an integer");
-            assert!(row["trust"].is_i64() || row["trust"].is_u64(), "trust must be an integer");
-            assert_eq!(row["rank"].as_u64().unwrap(), (i + 1) as u64, "ranks must be 1-indexed and sequential");
+            assert!(
+                row["credits"].is_i64() || row["credits"].is_u64(),
+                "credits must be an integer"
+            );
+            assert!(
+                row["trust"].is_i64() || row["trust"].is_u64(),
+                "trust must be an integer"
+            );
+            assert_eq!(
+                row["rank"].as_u64().unwrap(),
+                (i + 1) as u64,
+                "ranks must be 1-indexed and sequential"
+            );
         }
         // Verify sort invariant: credits must be non-increasing.
         for window in rows.windows(2) {
@@ -5567,7 +6143,11 @@ mod tests {
         let msg = messages
             .iter()
             .find(|m| m["id"].as_str() == Some(task_id.as_str()))
-            .or_else(|| messages.iter().find(|m| m["text"].as_str().unwrap_or("").contains("Ship API auth")))
+            .or_else(|| {
+                messages
+                    .iter()
+                    .find(|m| m["text"].as_str().unwrap_or("").contains("Ship API auth"))
+            })
             .expect("task message saved");
         assert_eq!(msg["from"].as_str(), Some("api-agent"));
     }
@@ -5581,7 +6161,8 @@ mod tests {
         let claimed = task_claim_as("api-agent", &task_id, None).unwrap();
         assert_eq!(claimed, task_id);
 
-        let checkpointed = task_checkpoint_as("api-agent", &task_id, Some("progress"), None).unwrap();
+        let checkpointed =
+            task_checkpoint_as("api-agent", &task_id, Some("progress"), None).unwrap();
         assert_eq!(checkpointed, task_id);
 
         let done = task_done_as("api-agent", &task_id, Some("done"), None).unwrap();
@@ -5596,10 +6177,7 @@ mod tests {
         let task_messages: Vec<_> = messages
             .iter()
             .filter(|m| {
-                m["text"]
-                    .as_str()
-                    .unwrap_or("")
-                    .contains("Ship API auth")
+                m["text"].as_str().unwrap_or("").contains("Ship API auth")
                     || m["text"].as_str().unwrap_or("").contains("progress")
                     || m["text"].as_str().unwrap_or("").contains("done")
             })
@@ -5619,7 +6197,8 @@ mod tests {
 
         let task_id = task_add_as("api-agent", "Review shady task", None).unwrap();
         task_claim_as("api-agent", &task_id, None).unwrap();
-        let rejected = task_reject_as("api-agent", &task_id, Some("scope is abusive"), None).unwrap();
+        let rejected =
+            task_reject_as("api-agent", &task_id, Some("scope is abusive"), None).unwrap();
         assert_eq!(rejected, task_id);
 
         let tasks = store::load_tasks(&room.room_id);
@@ -5639,7 +6218,12 @@ mod tests {
         let messages = store::load_messages(&room.room_id, 3600);
         let reject_msg = messages
             .iter()
-            .find(|m| m["text"].as_str().unwrap_or("").contains("Rejected by api-agent"))
+            .find(|m| {
+                m["text"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("Rejected by api-agent")
+            })
             .expect("reject message saved");
         assert_eq!(reject_msg["from"].as_str(), Some("api-agent"));
     }
@@ -5708,8 +6292,15 @@ mod tests {
         seed_agent_trust(&room.room_id, poster_id);
 
         // Post a bounty with a deadline 1 second in the future.
-        let id = bounty_post("Deadline test bounty", 3, None, Some(40), Some(0 /* 0h = already expired */), None)
-            .expect("bounty_post should succeed");
+        let id = bounty_post(
+            "Deadline test bounty",
+            3,
+            None,
+            Some(40),
+            Some(0 /* 0h = already expired */),
+            None,
+        )
+        .expect("bounty_post should succeed");
         let _ = id;
 
         // Verify credits were escrowed.
@@ -5740,7 +6331,10 @@ mod tests {
 
         // Running again should find nothing new.
         let expired2 = bounty_expire_check(None).expect("second expire check should succeed");
-        assert!(expired2.is_empty(), "no more expired bounties on second run");
+        assert!(
+            expired2.is_empty(),
+            "no more expired bounties on second run"
+        );
     }
 
     #[test]
@@ -5817,10 +6411,12 @@ pub fn search(
     let msgs = store::load_messages(&room.room_id, 604800);
 
     let re = if use_regex {
-        Some(regex::RegexBuilder::new(query)
-            .case_insensitive(true)
-            .build()
-            .map_err(|e| format!("Invalid regex: {e}"))?)
+        Some(
+            regex::RegexBuilder::new(query)
+                .case_insensitive(true)
+                .build()
+                .map_err(|e| format!("Invalid regex: {e}"))?,
+        )
     } else {
         None
     };
@@ -5875,11 +6471,7 @@ fn resolve_message_id(msgs: &[serde_json::Value], needle: &str) -> Result<String
         1 => Ok(matches[0].clone()),
         _ => Err(format!(
             "Message ID '{needle}' is ambiguous: {}",
-            matches
-                .into_iter()
-                .take(5)
-                .collect::<Vec<_>>()
-                .join(", ")
+            matches.into_iter().take(5).collect::<Vec<_>>().join(", ")
         )),
     }
 }
@@ -6028,7 +6620,9 @@ pub fn daemon(room_label: Option<&str>) -> Result<u32, String> {
     // Kill existing daemon if running
     if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
-            unsafe { libc::kill(pid, libc::SIGTERM); }
+            unsafe {
+                libc::kill(pid, libc::SIGTERM);
+            }
         }
         let _ = std::fs::remove_file(&pid_path);
     }
@@ -6049,7 +6643,9 @@ pub fn daemon(room_label: Option<&str>) -> Result<u32, String> {
     }
 
     // Child — daemon process
-    unsafe { libc::setsid(); }
+    unsafe {
+        libc::setsid();
+    }
 
     let room_key = crypto::derive_room_key(&secret, &room_id);
     let me = store::get_agent_id();
@@ -6114,7 +6710,9 @@ pub fn stop_daemon(room_label: Option<&str>) -> Result<(), String> {
     let pid_path = store::daemon_pid_path(&room.room_id);
     if let Ok(pid_str) = std::fs::read_to_string(&pid_path) {
         if let Ok(pid) = pid_str.trim().parse::<i32>() {
-            unsafe { libc::kill(pid, libc::SIGTERM); }
+            unsafe {
+                libc::kill(pid, libc::SIGTERM);
+            }
             let _ = std::fs::remove_file(pid_path);
             return Ok(());
         }
@@ -6125,8 +6723,8 @@ pub fn stop_daemon(room_label: Option<&str>) -> Result<(), String> {
 pub fn verify(room_label: Option<&str>) -> Result<serde_json::Value, String> {
     let room = resolve_room(room_label)?;
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let (nonce, commitment) = crypto::zkp_create_commitment(&room_key)
-        .map_err(|e| e.to_string())?;
+    let (nonce, commitment) =
+        crypto::zkp_create_commitment(&room_key).map_err(|e| e.to_string())?;
     let challenge = crypto::zkp_create_challenge().map_err(|e| e.to_string())?;
     let response = crypto::zkp_respond(&room_key, &nonce, &challenge);
     let valid = crypto::zkp_verify(&room_key, &nonce, &challenge, &response);
@@ -6161,7 +6759,7 @@ pub fn agent_leaderboard() -> Vec<serde_json::Value> {
 
     // Accumulate per-agent totals across all rooms.
     let mut credits: HashMap<String, i64> = HashMap::new();
-    let mut trust:   HashMap<String, i64> = HashMap::new();
+    let mut trust: HashMap<String, i64> = HashMap::new();
 
     for room in &rooms {
         for entry in store::load_ledger(&room.room_id) {
@@ -6193,9 +6791,9 @@ pub fn agent_leaderboard() -> Vec<serde_json::Value> {
     rows.into_iter()
         .enumerate()
         .map(|(i, (agent_id, c, t))| {
-            let display = aliases.get(&agent_id)
-                .cloned()
-                .unwrap_or_else(|| format!("{}…{}", &agent_id[..4], &agent_id[agent_id.len()-4..]));
+            let display = aliases.get(&agent_id).cloned().unwrap_or_else(|| {
+                format!("{}…{}", &agent_id[..4], &agent_id[agent_id.len() - 4..])
+            });
             serde_json::json!({
                 "rank": i + 1,
                 "agent_id": agent_id,
@@ -6237,15 +6835,20 @@ pub fn economy_stats() -> serde_json::Value {
         total_trust += room_trust;
 
         let msgs = store::load_messages(&room.room_id, 604800);
-        let room_open: Vec<_> = msgs.iter()
-            .filter(|m| m["type"].as_str() == Some("bounty") && m["status"].as_str() == Some("open"))
-            .map(|m| serde_json::json!({
-                "id": m["id"],
-                "title": m["title"],
-                "reward_credits": m["reward_credits"],
-                "priority": m["priority"],
-                "room": room.label,
-            }))
+        let room_open: Vec<_> = msgs
+            .iter()
+            .filter(|m| {
+                m["type"].as_str() == Some("bounty") && m["status"].as_str() == Some("open")
+            })
+            .map(|m| {
+                serde_json::json!({
+                    "id": m["id"],
+                    "title": m["title"],
+                    "reward_credits": m["reward_credits"],
+                    "priority": m["priority"],
+                    "room": room.label,
+                })
+            })
             .collect();
         open_bounties.extend(room_open.clone());
 
@@ -6299,20 +6902,44 @@ pub fn economy_stats() -> serde_json::Value {
 }
 
 /// Transfer credits between agents.
-pub fn credit_transfer(to_agent: &str, amount: i64, reason: Option<&str>, room_label: Option<&str>) -> Result<(i64, i64), String> {
+pub fn credit_transfer(
+    to_agent: &str,
+    amount: i64,
+    reason: Option<&str>,
+    room_label: Option<&str>,
+) -> Result<(i64, i64), String> {
     let room = resolve_room(room_label)?;
     let me = store::get_agent_id();
-    if me == to_agent { return Err("Cannot transfer to yourself.".to_string()); }
+    if me == to_agent {
+        return Err("Cannot transfer to yourself.".to_string());
+    }
     let balance = store::credit_balance(&room.room_id, &me);
-    if balance < amount { return Err(format!("Insufficient credits: have {balance}, need {amount}")); }
+    if balance < amount {
+        return Err(format!(
+            "Insufficient credits: have {balance}, need {amount}"
+        ));
+    }
     let reason_str = reason.unwrap_or("transfer");
-    store::credit_add(&room.room_id, &me, -amount, &format!("sent to {to_agent}: {reason_str}"));
-    store::credit_add(&room.room_id, to_agent, amount, &format!("received from {me}: {reason_str}"));
+    store::credit_add(
+        &room.room_id,
+        &me,
+        -amount,
+        &format!("sent to {to_agent}: {reason_str}"),
+    );
+    store::credit_add(
+        &room.room_id,
+        to_agent,
+        amount,
+        &format!("received from {me}: {reason_str}"),
+    );
     let my_balance = store::credit_balance(&room.room_id, &me);
     let their_balance = store::credit_balance(&room.room_id, to_agent);
 
     let room_key = crypto::derive_room_key(&room.secret, &room.room_id);
-    let env = make_envelope(&format!("[transfer] {me} → {to_agent}: {amount} credits ({reason_str})"), None);
+    let env = make_envelope(
+        &format!("[transfer] {me} → {to_agent}: {amount} credits ({reason_str})"),
+        None,
+    );
     let encrypted = encrypt_envelope(&env, &room_key, &room.room_id);
     transport::publish(&room.room_id, &encrypted);
     store::save_message(&room.room_id, &env);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -7,8 +7,8 @@
 //! - Room-specific symmetric keys derived from the shared secret
 //! - Zero-knowledge room membership proof (HMAC challenge-response)
 
-use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey, NONCE_LEN};
-use ring::hkdf::{self, Salt, HKDF_SHA256};
+use ring::aead::{self, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
+use ring::hkdf::{self, HKDF_SHA256, Salt};
 use ring::hmac;
 use ring::rand::{SecureRandom, SystemRandom};
 use ring::signature::{ED25519, Ed25519KeyPair, KeyPair, UnparsedPublicKey};
@@ -112,7 +112,8 @@ pub fn derive_msg_key(chain_key: &[u8; 32]) -> [u8; 32] {
 pub fn encrypt(plaintext: &[u8], key: &[u8; 32], aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
     let rng = SystemRandom::new();
     let mut nonce_bytes = [0u8; NONCE_LEN];
-    rng.fill(&mut nonce_bytes).map_err(|_| CryptoError::RngFailed)?;
+    rng.fill(&mut nonce_bytes)
+        .map_err(|_| CryptoError::RngFailed)?;
 
     let unbound = UnboundKey::new(&aead::AES_256_GCM, key).map_err(|_| CryptoError::InvalidKey)?;
     let sealing_key = LessSafeKey::new(unbound);
@@ -139,7 +140,8 @@ pub fn decrypt(blob: &[u8], key: &[u8; 32], aad: &[u8]) -> Result<Vec<u8>, Crypt
     }
 
     let (nonce_bytes, ciphertext_with_tag) = blob.split_at(NONCE_LEN);
-    let nonce = Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| CryptoError::DecryptionFailed)?;
+    let nonce =
+        Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| CryptoError::DecryptionFailed)?;
 
     let unbound = UnboundKey::new(&aead::AES_256_GCM, key).map_err(|_| CryptoError::InvalidKey)?;
     let opening_key = LessSafeKey::new(unbound);
@@ -172,7 +174,8 @@ pub fn zkp_create_commitment(room_key: &[u8; 32]) -> Result<([u8; 32], [u8; 32])
 pub fn zkp_create_challenge() -> Result<[u8; 32], CryptoError> {
     let rng = SystemRandom::new();
     let mut challenge = [0u8; 32];
-    rng.fill(&mut challenge).map_err(|_| CryptoError::RngFailed)?;
+    rng.fill(&mut challenge)
+        .map_err(|_| CryptoError::RngFailed)?;
     Ok(challenge)
 }
 
@@ -238,9 +241,9 @@ pub fn generate_signing_keypair_from_seed(seed: &[u8; 32]) -> Result<Vec<u8>, Cr
         0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70,      // SEQUENCE { OID 1.3.101.112 }
         0x04, 0x22, 0x04, 0x20,                         // OCTET STRING(34) { OCTET STRING(32) }
     ];
-    pkcs8.extend_from_slice(seed);           // 32-byte private key seed
+    pkcs8.extend_from_slice(seed); // 32-byte private key seed
     pkcs8.extend_from_slice(&[0x81, 0x21, 0x00]); // [1] IMPLICIT BIT STRING(33), no unused bits
-    pkcs8.extend_from_slice(pubkey);          // 32-byte compressed Edwards point
+    pkcs8.extend_from_slice(pubkey); // 32-byte compressed Edwards point
 
     // Validate round-trip before returning.
     Ed25519KeyPair::from_pkcs8(&pkcs8).map_err(|_| CryptoError::InvalidKey)?;
@@ -511,7 +514,10 @@ mod tests {
         let seed_b = [0x02u8; 32];
         let pkcs8_a = generate_signing_keypair_from_seed(&seed_a).unwrap();
         let pkcs8_b = generate_signing_keypair_from_seed(&seed_b).unwrap();
-        assert_ne!(pkcs8_a, pkcs8_b, "different seeds must produce different keypairs");
+        assert_ne!(
+            pkcs8_a, pkcs8_b,
+            "different seeds must produce different keypairs"
+        );
     }
 
     #[test]
@@ -521,7 +527,10 @@ mod tests {
         let pubkey = signing_public_key(&pkcs8).unwrap();
         let msg = b"test message for signing";
         let sig = sign_message(&pkcs8, msg).unwrap();
-        assert!(verify_message_signature(&pubkey, msg, &sig), "seed-derived key must sign/verify");
+        assert!(
+            verify_message_signature(&pubkey, msg, &sig),
+            "seed-derived key must sign/verify"
+        );
     }
 
     #[test]
@@ -529,6 +538,9 @@ mod tests {
         let seed = [0x55u8; 32];
         let seed_pkcs8 = generate_signing_keypair_from_seed(&seed).unwrap();
         let random_pkcs8 = generate_signing_keypair_pkcs8().unwrap();
-        assert_ne!(seed_pkcs8, random_pkcs8, "seed-derived must differ from random");
+        assert_ne!(
+            seed_pkcs8, random_pkcs8,
+            "seed-derived must differ from random"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -805,7 +805,9 @@ enum Commands {
 /// Parse a time argument: "HH:MM" (today), "1h" (relative), or unix timestamp.
 fn parse_time_arg(s: &str) -> Option<u64> {
     let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).ok()?.as_secs();
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
     // Relative: "1h", "30m", "2d"
     if let Some(h) = s.strip_suffix('h') {
         return Some(now - h.parse::<u64>().ok()? * 3600);
@@ -912,14 +914,12 @@ fn sign_invite_token(payload: InviteTokenPayload) -> Result<String, String> {
         .clone()
         .unwrap_or_else(store::get_agent_id);
     let pkcs8 = store::load_or_create_signing_keypair(&created_by)?;
-    let inviter_signing_pubkey = BASE64.encode(
-        crypto::signing_public_key(&pkcs8).map_err(|e| e.to_string())?,
-    );
+    let inviter_signing_pubkey =
+        BASE64.encode(crypto::signing_public_key(&pkcs8).map_err(|e| e.to_string())?);
     store::trust_signing_key(&created_by, &inviter_signing_pubkey);
     let signing_input = invite_signing_message_bytes(&payload, &inviter_signing_pubkey);
-    let sig = BASE64.encode(
-        crypto::sign_message(&pkcs8, &signing_input).map_err(|e| e.to_string())?,
-    );
+    let sig =
+        BASE64.encode(crypto::sign_message(&pkcs8, &signing_input).map_err(|e| e.to_string())?);
     let token = SignedInviteToken {
         v: SIGNED_INVITE_VERSION.to_string(),
         payload,
@@ -1001,25 +1001,25 @@ fn parse_invite_token(token: &str) -> Result<ParsedInviteToken, String> {
     }
 
     Ok(ParsedInviteToken {
-            payload: InviteTokenPayload {
-                room_id: parts[0].to_string(),
-                secret: parts[1].to_string(),
-                label: if parts.len() == 3 {
-                    parts[2].to_string()
-                } else {
-                    parts[0][..12.min(parts[0].len())].to_string()
-                },
-                invite_id: None,
-                target_agent_id: None,
-                target_signing_pubkey: None,
-                purpose: None,
-                expires_at: None,
-                max_uses: None,
-                created_by: None,
-                issued_at: None,
+        payload: InviteTokenPayload {
+            room_id: parts[0].to_string(),
+            secret: parts[1].to_string(),
+            label: if parts.len() == 3 {
+                parts[2].to_string()
+            } else {
+                parts[0][..12.min(parts[0].len())].to_string()
             },
-            auth: InviteTokenAuth::Unsigned,
-        })
+            invite_id: None,
+            target_agent_id: None,
+            target_signing_pubkey: None,
+            purpose: None,
+            expires_at: None,
+            max_uses: None,
+            created_by: None,
+            issued_at: None,
+        },
+        auth: InviteTokenAuth::Unsigned,
+    })
 }
 
 fn print_msg(env: &serde_json::Value) {
@@ -1094,7 +1094,9 @@ fn print_soma_details(belief: &serde_json::Value) {
 
 fn print_msg_with_depth(env: &serde_json::Value, depth: usize) {
     match env["type"].as_str() {
-        Some("heartbeat" | "receipt" | "reaction" | "invite_redeem" | "work_receipt" | "role_state") => return,
+        Some(
+            "heartbeat" | "receipt" | "reaction" | "invite_redeem" | "work_receipt" | "role_state",
+        ) => return,
         _ => {}
     }
     let time = ts(env["ts"].as_u64().unwrap_or(0));
@@ -1125,29 +1127,31 @@ fn main() {
     let room = cli.room.as_deref();
 
     match cli.command {
-        Commands::Create { label } => {
-            match chat::create(&label) {
-                Ok((room_id, secret)) => {
-                    let room_key = crypto::derive_room_key(&secret, &room_id);
-                    println!("  Created encrypted room '{label}'");
-                    println!("  Room ID:    {room_id}");
-                    println!("  Secret:     {secret}");
-                    println!("  Encryption: AES-256-GCM + HKDF-SHA256");
-                    println!();
-                    println!("  Share this join command:");
-                    println!("    agora join {room_id} {secret} {label}");
-                    println!();
-                    println!("  Key fingerprint (verify out-of-band):");
-                    println!("    {}", crypto::fingerprint(&room_key));
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::Create { label } => match chat::create(&label) {
+            Ok((room_id, secret)) => {
+                let room_key = crypto::derive_room_key(&secret, &room_id);
+                println!("  Created encrypted room '{label}'");
+                println!("  Room ID:    {room_id}");
+                println!("  Secret:     {secret}");
+                println!("  Encryption: AES-256-GCM + HKDF-SHA256");
+                println!();
+                println!("  Share this join command:");
+                println!("    agora join {room_id} {secret} {label}");
+                println!();
+                println!("  Key fingerprint (verify out-of-band):");
+                println!("    {}", crypto::fingerprint(&room_key));
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Join { room_id, secret, label } => {
+        Commands::Join {
+            room_id,
+            secret,
+            label,
+        } => {
             let label = label.unwrap_or_else(|| room_id[..12.min(room_id.len())].to_string());
             match chat::join(&room_id, &secret, &label) {
                 Ok(_) => {
@@ -1164,16 +1168,27 @@ fn main() {
         }
 
         Commands::Invite { expires, max_uses } => {
-            let active = if let Some(r) = room { store::find_room(r) } else { store::get_active_room() };
+            let active = if let Some(r) = room {
+                store::find_room(r)
+            } else {
+                store::get_active_room()
+            };
             match active {
                 Some(r) => {
                     let now_ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs();
                     let expires_at = expires.as_ref().and_then(|e| {
-                        let secs = if let Some(h) = e.strip_suffix('h') { h.parse::<u64>().ok().map(|v| v * 3600) }
-                        else if let Some(d) = e.strip_suffix('d') { d.parse::<u64>().ok().map(|v| v * 86400) }
-                        else if let Some(m) = e.strip_suffix('m') { m.parse::<u64>().ok().map(|v| v * 60) }
-                        else { None };
+                        let secs = if let Some(h) = e.strip_suffix('h') {
+                            h.parse::<u64>().ok().map(|v| v * 3600)
+                        } else if let Some(d) = e.strip_suffix('d') {
+                            d.parse::<u64>().ok().map(|v| v * 86400)
+                        } else if let Some(m) = e.strip_suffix('m') {
+                            m.parse::<u64>().ok().map(|v| v * 60)
+                        } else {
+                            None
+                        };
                         secs.map(|s| now_ts + s)
                     });
                     let payload = InviteTokenPayload {
@@ -1221,7 +1236,9 @@ fn main() {
                     // Check expiry
                     if let Some(expires_at) = payload.expires_at {
                         let now_ts = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap()
+                            .as_secs();
                         if now_ts > expires_at {
                             eprintln!("  Error: invite token has expired.");
                             process::exit(1);
@@ -1235,7 +1252,9 @@ fn main() {
                                 "  Error: invite token is intended for '{}' but your agent ID is '{}'.",
                                 target, me
                             );
-                            eprintln!("  Note: agent IDs are not authenticated yet; this is a soft guardrail.");
+                            eprintln!(
+                                "  Note: agent IDs are not authenticated yet; this is a soft guardrail."
+                            );
                             process::exit(1);
                         }
                     }
@@ -1298,7 +1317,8 @@ fn main() {
                                     eprintln!("  Warning: failed to record invite redemption: {e}");
                                 }
                             }
-                            let room_key = crypto::derive_room_key(&payload.secret, &payload.room_id);
+                            let room_key =
+                                crypto::derive_room_key(&payload.secret, &payload.room_id);
                             println!("  Joined room '{}'", payload.label);
                             println!("  Encryption: AES-256-GCM + HKDF-SHA256");
                             println!("  Fingerprint: {}", crypto::fingerprint(&room_key));
@@ -1310,7 +1330,9 @@ fn main() {
                                     println!("  Invite signature: unsigned legacy token");
                                 }
                             }
-                            if let (Some(used_before), Some(max_uses)) = (redemption_count, payload.max_uses) {
+                            if let (Some(used_before), Some(max_uses)) =
+                                (redemption_count, payload.max_uses)
+                            {
                                 println!(
                                     "  Invite uses: {}/{} (best-effort decentralized check)",
                                     used_before + 1,
@@ -1461,7 +1483,10 @@ fn main() {
                 process::exit(1);
             }
             match chat::send(&text, reply.as_deref(), room) {
-                Ok(mid) => println!("  Sent [{}] (AES-256-GCM encrypted)", &mid[..6.min(mid.len())]),
+                Ok(mid) => println!(
+                    "  Sent [{}] (AES-256-GCM encrypted)",
+                    &mid[..6.min(mid.len())]
+                ),
                 Err(e) => {
                     eprintln!("  Error: {e}");
                     process::exit(1);
@@ -1469,64 +1494,68 @@ fn main() {
             }
         }
 
-        Commands::Read { tail } => {
-            match chat::read("2h", 50, room) {
-                Ok(msgs) => {
-                    let msgs = if let Some(n) = tail {
-                        if msgs.len() > n { &msgs[msgs.len() - n..] } else { &msgs }
+        Commands::Read { tail } => match chat::read("2h", 50, room) {
+            Ok(msgs) => {
+                let msgs = if let Some(n) = tail {
+                    if msgs.len() > n {
+                        &msgs[msgs.len() - n..]
                     } else {
                         &msgs
-                    };
-                    if msgs.is_empty() {
-                        println!("  (no messages)");
-                        return;
                     }
-                    let header_room = if let Some(target) = room {
-                        store::find_room(target)
-                    } else {
-                        store::get_active_room()
-                    };
-                    if let Some(header_room) = header_room {
-                        println!("  --- {} ({} messages, AES-256-GCM) ---\n", header_room.label, msgs.len());
-                    }
-                    if let Ok(pinned) = chat::pins(room) {
-                        if !pinned.is_empty() {
-                            println!("  --- pinned ({}) ---\n", pinned.len());
-                            for p in &pinned {
-                                print_msg(p);
-                            }
-                            println!();
+                } else {
+                    &msgs
+                };
+                if msgs.is_empty() {
+                    println!("  (no messages)");
+                    return;
+                }
+                let header_room = if let Some(target) = room {
+                    store::find_room(target)
+                } else {
+                    store::get_active_room()
+                };
+                if let Some(header_room) = header_room {
+                    println!(
+                        "  --- {} ({} messages, AES-256-GCM) ---\n",
+                        header_room.label,
+                        msgs.len()
+                    );
+                }
+                if let Ok(pinned) = chat::pins(room) {
+                    if !pinned.is_empty() {
+                        println!("  --- pinned ({}) ---\n", pinned.len());
+                        for p in &pinned {
+                            print_msg(p);
                         }
+                        println!();
                     }
-                    for m in msgs {
+                }
+                for m in msgs {
+                    print_msg(m);
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Check { wake } => match chat::check("5m", room) {
+            Ok(msgs) => {
+                if !msgs.is_empty() {
+                    for m in &msgs {
                         print_msg(m);
                     }
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
-            }
-        }
-
-        Commands::Check { wake } => {
-            match chat::check("5m", room) {
-                Ok(msgs) => {
-                    if !msgs.is_empty() {
-                        for m in &msgs {
-                            print_msg(m);
-                        }
-                        if wake {
-                            process::exit(2);
-                        }
+                    if wake {
+                        process::exit(2);
                     }
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Rooms => {
             let rooms = store::load_registry();
@@ -1537,126 +1566,157 @@ fn main() {
             let active = store::get_active_room();
             let active_id = active.map(|r| r.room_id).unwrap_or_default();
             println!("  {:<20} {:<22} {:<8} Joined", "Label", "Room ID", "Active");
-            println!("  {:<20} {:<22} {:<8} {}", "─".repeat(20), "─".repeat(22), "─".repeat(8), "─".repeat(20));
+            println!(
+                "  {:<20} {:<22} {:<8} {}",
+                "─".repeat(20),
+                "─".repeat(22),
+                "─".repeat(8),
+                "─".repeat(20)
+            );
             for r in &rooms {
                 let is_active = if r.room_id == active_id { " *" } else { "" };
                 let joined = chrono::DateTime::from_timestamp(r.joined_at as i64, 0)
                     .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
                     .unwrap_or_default();
-                println!("  {:<20} {:<22} {:<8} {joined}", r.label, r.room_id, is_active);
+                println!(
+                    "  {:<20} {:<22} {:<8} {joined}",
+                    r.label, r.room_id, is_active
+                );
             }
         }
 
-        Commands::Switch { label } => {
-            match store::find_room(&label) {
-                Some(_) => {
-                    store::set_active_room(&label);
-                    println!("  Switched to '{label}'");
+        Commands::Switch { label } => match store::find_room(&label) {
+            Some(_) => {
+                store::set_active_room(&label);
+                println!("  Switched to '{label}'");
+            }
+            None => {
+                eprintln!("  Room '{label}' not found. Run: agora rooms");
+                process::exit(1);
+            }
+        },
+
+        Commands::Leave => match chat::leave(room) {
+            Ok(info) => {
+                println!("  Left room '{}'.", info["label"].as_str().unwrap_or("?"));
+                if info["daemon_stopped"].as_bool().unwrap_or(false) {
+                    println!("  Daemon stopped.");
                 }
-                None => {
-                    eprintln!("  Room '{label}' not found. Run: agora rooms");
-                    process::exit(1);
+                if let Some(active_room) = info["active_room"].as_str() {
+                    println!("  Active room: {active_room}");
+                } else {
+                    println!("  No rooms left.");
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Leave => {
-            match chat::leave(room) {
-                Ok(info) => {
-                    println!("  Left room '{}'.", info["label"].as_str().unwrap_or("?"));
-                    if info["daemon_stopped"].as_bool().unwrap_or(false) {
-                        println!("  Daemon stopped.");
-                    }
-                    if let Some(active_room) = info["active_room"].as_str() {
-                        println!("  Active room: {active_room}");
+        Commands::Info => match chat::info(room) {
+            Ok(info) => {
+                println!("  Room:        {}", info["label"].as_str().unwrap_or("?"));
+                println!("  ID:          {}", info["room_id"].as_str().unwrap_or("?"));
+                if let Some(topic) = info["topic"].as_str() {
+                    println!("  Topic:       {topic}");
+                }
+                println!(
+                    "  Encryption:  {}",
+                    info["encryption"].as_str().unwrap_or("?")
+                );
+                println!(
+                    "  KDF:         {}",
+                    info["key_derivation"].as_str().unwrap_or("?")
+                );
+                println!("  Messages:    {}", info["messages"].as_u64().unwrap_or(0));
+                let member_count = info["members"].as_array().map(|a| a.len()).unwrap_or(0);
+                println!("  Members:     {member_count}");
+                println!(
+                    "  Fingerprint: {}",
+                    info["fingerprint"].as_str().unwrap_or("?")
+                );
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Who { online } => match chat::who(room, online) {
+            Ok(members) => {
+                if members.is_empty() {
+                    if online {
+                        println!("  No one online (seen in last 5 minutes).");
                     } else {
-                        println!("  No rooms left.");
+                        println!("  No members tracked yet.");
                     }
+                    return;
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
-            }
-        }
-
-        Commands::Info => {
-            match chat::info(room) {
-                Ok(info) => {
-                    println!("  Room:        {}", info["label"].as_str().unwrap_or("?"));
-                    println!("  ID:          {}", info["room_id"].as_str().unwrap_or("?"));
-                    if let Some(topic) = info["topic"].as_str() {
-                        println!("  Topic:       {topic}");
-                    }
-                    println!("  Encryption:  {}", info["encryption"].as_str().unwrap_or("?"));
-                    println!("  KDF:         {}", info["key_derivation"].as_str().unwrap_or("?"));
-                    println!("  Messages:    {}", info["messages"].as_u64().unwrap_or(0));
-                    let member_count = info["members"].as_array().map(|a| a.len()).unwrap_or(0);
-                    println!("  Members:     {member_count}");
-                    println!("  Fingerprint: {}", info["fingerprint"].as_str().unwrap_or("?"));
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
-            }
-        }
-
-        Commands::Who { online } => {
-            match chat::who(room, online) {
-                Ok(members) => {
-                    if members.is_empty() {
-                        if online {
-                            println!("  No one online (seen in last 5 minutes).");
+                let me = store::get_agent_id();
+                let now_ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                println!(
+                    "  {:<20} {:<12} {:<8} {:<10} Last seen",
+                    "Name", "Agent", "Role", "Status"
+                );
+                println!(
+                    "  {:<20} {:<12} {:<8} {:<10} {}",
+                    "─".repeat(20),
+                    "─".repeat(12),
+                    "─".repeat(8),
+                    "─".repeat(10),
+                    "─".repeat(16)
+                );
+                for m in &members {
+                    let role = format!("{:?}", m.role);
+                    let is_me = if m.agent_id == me { " (you)" } else { "" };
+                    let display = resolve_display_name(&m.agent_id);
+                    let name = if display == m.agent_id {
+                        "".to_string()
+                    } else {
+                        display
+                    };
+                    let status = if m.last_seen > 0 && now_ts - m.last_seen < 300 {
+                        "\x1b[92monline\x1b[0m"
+                    } else if m.last_seen > 0 {
+                        "offline"
+                    } else {
+                        "unknown"
+                    };
+                    let seen = if m.last_seen > 0 {
+                        let ago = now_ts - m.last_seen;
+                        if ago < 60 {
+                            format!("{ago}s ago")
+                        } else if ago < 3600 {
+                            format!("{}m ago", ago / 60)
                         } else {
-                            println!("  No members tracked yet.");
+                            format!("{}h ago", ago / 3600)
                         }
-                        return;
-                    }
-                    let me = store::get_agent_id();
-                    let now_ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-                    println!("  {:<20} {:<12} {:<8} {:<10} Last seen", "Name", "Agent", "Role", "Status");
-                    println!("  {:<20} {:<12} {:<8} {:<10} {}", "─".repeat(20), "─".repeat(12), "─".repeat(8), "─".repeat(10), "─".repeat(16));
-                    for m in &members {
-                        let role = format!("{:?}", m.role);
-                        let is_me = if m.agent_id == me { " (you)" } else { "" };
-                        let display = resolve_display_name(&m.agent_id);
-                        let name = if display == m.agent_id { "".to_string() } else { display };
-                        let status = if m.last_seen > 0 && now_ts - m.last_seen < 300 {
-                            "\x1b[92monline\x1b[0m"
-                        } else if m.last_seen > 0 {
-                            "offline"
-                        } else {
-                            "unknown"
-                        };
-                        let seen = if m.last_seen > 0 {
-                            let ago = now_ts - m.last_seen;
-                            if ago < 60 { format!("{ago}s ago") }
-                            else if ago < 3600 { format!("{}m ago", ago / 60) }
-                            else { format!("{}h ago", ago / 3600) }
-                        } else {
-                            "never".to_string()
-                        };
-                        println!("  {:<20} {:<12} {:<8} {:<18} {seen}{is_me}", name, m.agent_id, role, status);
-                    }
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
+                    } else {
+                        "never".to_string()
+                    };
+                    println!(
+                        "  {:<20} {:<12} {:<8} {:<18} {seen}{is_me}",
+                        name, m.agent_id, role, status
+                    );
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Heartbeat => {
-            match chat::heartbeat(room) {
-                Ok(()) => println!("  Heartbeat sent."),
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::Heartbeat => match chat::heartbeat(room) {
+            Ok(()) => println!("  Heartbeat sent."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
         Commands::Topic { text } => {
             let topic = text.join(" ");
@@ -1673,59 +1733,68 @@ fn main() {
             }
         }
 
-        Commands::Promote { agent_id } => {
-            match chat::promote(&agent_id, room) {
-                Ok(()) => println!("  Promoted {agent_id} to admin."),
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::Promote { agent_id } => match chat::promote(&agent_id, room) {
+            Ok(()) => println!("  Promoted {agent_id} to admin."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::Kick { agent_id } => {
-            match chat::kick(&agent_id, room) {
-                Ok(()) => println!("  Kicked {agent_id}."),
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::Kick { agent_id } => match chat::kick(&agent_id, room) {
+            Ok(()) => println!("  Kicked {agent_id}."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::Delete { msg_id } => {
-            match chat::delete_message(&msg_id, room) {
-                Ok(()) => println!("  Message [{msg_id}] deleted."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::Delete { msg_id } => match chat::delete_message(&msg_id, room) {
+            Ok(()) => println!("  Message [{msg_id}] deleted."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::Verify => {
-            match chat::verify(room) {
-                Ok(proof) => {
-                    let valid = proof["proof_valid"].as_bool().unwrap_or(false);
-                    println!("  Room: {}", proof["room_id"].as_str().unwrap_or("?"));
-                    println!("  ZKP membership proof: {}", if valid { "VALID" } else { "INVALID" });
-                    let nonce = proof["nonce"].as_str().unwrap_or("");
-                    let commitment = proof["commitment"].as_str().unwrap_or("");
-                    let challenge = proof["challenge"].as_str().unwrap_or("");
-                    let response = proof["response"].as_str().unwrap_or("");
-                    println!("  Nonce:      {}...", &nonce[..32.min(nonce.len())]);
-                    println!("  Commitment: {}...", &commitment[..32.min(commitment.len())]);
-                    println!("  Challenge:  {}...", &challenge[..32.min(challenge.len())]);
-                    println!("  Response:   {}...", &response[..32.min(response.len())]);
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::Verify => match chat::verify(room) {
+            Ok(proof) => {
+                let valid = proof["proof_valid"].as_bool().unwrap_or(false);
+                println!("  Room: {}", proof["room_id"].as_str().unwrap_or("?"));
+                println!(
+                    "  ZKP membership proof: {}",
+                    if valid { "VALID" } else { "INVALID" }
+                );
+                let nonce = proof["nonce"].as_str().unwrap_or("");
+                let commitment = proof["commitment"].as_str().unwrap_or("");
+                let challenge = proof["challenge"].as_str().unwrap_or("");
+                let response = proof["response"].as_str().unwrap_or("");
+                println!("  Nonce:      {}...", &nonce[..32.min(nonce.len())]);
+                println!(
+                    "  Commitment: {}...",
+                    &commitment[..32.min(commitment.len())]
+                );
+                println!("  Challenge:  {}...", &challenge[..32.min(challenge.len())]);
+                println!("  Response:   {}...", &response[..32.min(response.len())]);
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Search { query, from, after, before, regex: use_regex } => {
+        Commands::Search {
+            query,
+            from,
+            after,
+            before,
+            regex: use_regex,
+        } => {
             let q = query.join(" ");
             if q.is_empty() {
-                eprintln!("Usage: agora search <query> [--from <id>] [--after HH:MM] [--before HH:MM] [--regex]");
+                eprintln!(
+                    "Usage: agora search <query> [--from <id>] [--after HH:MM] [--before HH:MM] [--regex]"
+                );
                 process::exit(1);
             }
             let after_ts = after.and_then(|t| parse_time_arg(&t));
@@ -1748,84 +1817,79 @@ fn main() {
             }
         }
 
-        Commands::Pin { message_id } => {
-            match chat::pin(&message_id, room) {
-                Ok((resolved_id, added)) => {
-                    let short = &resolved_id[..6.min(resolved_id.len())];
-                    if added {
-                        println!("  Pinned [{short}].");
-                    } else {
-                        println!("  Already pinned [{short}].");
-                    }
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
+        Commands::Pin { message_id } => match chat::pin(&message_id, room) {
+            Ok((resolved_id, added)) => {
+                let short = &resolved_id[..6.min(resolved_id.len())];
+                if added {
+                    println!("  Pinned [{short}].");
+                } else {
+                    println!("  Already pinned [{short}].");
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Unpin { message_id } => {
-            match chat::unpin(&message_id, room) {
-                Ok((resolved_id, removed)) => {
-                    let short = &resolved_id[..6.min(resolved_id.len())];
-                    if removed {
-                        println!("  Unpinned [{short}].");
-                    } else {
-                        println!("  [{short}] was not pinned.");
-                    }
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
+        Commands::Unpin { message_id } => match chat::unpin(&message_id, room) {
+            Ok((resolved_id, removed)) => {
+                let short = &resolved_id[..6.min(resolved_id.len())];
+                if removed {
+                    println!("  Unpinned [{short}].");
+                } else {
+                    println!("  [{short}] was not pinned.");
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Pins => {
-            match chat::pins(room) {
-                Ok(pinned) => {
-                    if pinned.is_empty() {
-                        println!("  (no pinned messages)");
-                        return;
-                    }
-                    println!("  {} pinned message(s):\n", pinned.len());
-                    for p in &pinned {
-                        print_msg(p);
-                    }
+        Commands::Pins => match chat::pins(room) {
+            Ok(pinned) => {
+                if pinned.is_empty() {
+                    println!("  (no pinned messages)");
+                    return;
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
+                println!("  {} pinned message(s):\n", pinned.len());
+                for p in &pinned {
+                    print_msg(p);
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Thread { message_id } => {
-            match chat::thread(&message_id, room) {
-                Ok(items) => {
-                    if items.is_empty() {
-                        println!("  (no thread messages)");
-                        return;
-                    }
-                    println!("  Thread for '{message_id}':\n");
-                    for item in &items {
-                        print_msg_with_depth(&item.env, item.depth);
-                    }
+        Commands::Thread { message_id } => match chat::thread(&message_id, room) {
+            Ok(items) => {
+                if items.is_empty() {
+                    println!("  (no thread messages)");
+                    return;
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
+                println!("  Thread for '{message_id}':\n");
+                for item in &items {
+                    print_msg_with_depth(&item.env, item.depth);
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Recap { since } => {
             match chat::recap(&since, room) {
                 Ok(info) => {
                     let room_name = info["room"].as_str().unwrap_or("?");
                     let total = info["total_messages"].as_u64().unwrap_or(0);
-                    println!("  ╔═══ Recap: {} ({} messages, last {}) ═══╗\n", room_name, total, since);
+                    println!(
+                        "  ╔═══ Recap: {} ({} messages, last {}) ═══╗\n",
+                        room_name, total, since
+                    );
 
                     if total == 0 {
                         println!("  No activity.");
@@ -1854,9 +1918,8 @@ fn main() {
                     if let Some(kws) = info["top_keywords"].as_array() {
                         if !kws.is_empty() {
                             println!("\n  Topics:");
-                            let words: Vec<_> = kws.iter()
-                                .filter_map(|k| k["word"].as_str())
-                                .collect();
+                            let words: Vec<_> =
+                                kws.iter().filter_map(|k| k["word"].as_str()).collect();
                             println!("    {}", words.join(", "));
                         }
                     }
@@ -1870,43 +1933,57 @@ fn main() {
             }
         }
 
-        Commands::SendFile { path } => {
-            match chat::send_file(&path, room) {
-                Ok((file_id, size)) => {
-                    println!("  Sent file [{file_id}] ({size} bytes, AES-256-GCM encrypted)");
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::SendFile { path } => match chat::send_file(&path, room) {
+            Ok((file_id, size)) => {
+                println!("  Sent file [{file_id}] ({size} bytes, AES-256-GCM encrypted)");
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Files => {
-            match chat::list_files(room) {
-                Ok(files) => {
-                    if files.is_empty() {
-                        println!("  (no files shared)");
-                        return;
-                    }
-                    println!("  {:<10} {:<20} {:>10} {:<12} {}", "ID", "Filename", "Size", "From", "Time");
-                    println!("  {:<10} {:<20} {:>10} {:<12} {}", "─".repeat(10), "─".repeat(20), "─".repeat(10), "─".repeat(12), "─".repeat(8));
-                    for f in &files {
-                        let fid = &f["file_id"].as_str().unwrap_or("?")[..6.min(f["file_id"].as_str().unwrap_or("?").len())];
-                        let name = f["filename"].as_str().unwrap_or("?");
-                        let size = f["size"].as_u64().unwrap_or(0);
-                        let from = f["from"].as_str().unwrap_or("?");
-                        let time = ts(f["ts"].as_u64().unwrap_or(0));
-                        let size_str = if size > 1024 { format!("{}KB", size / 1024) } else { format!("{}B", size) };
-                        println!("  {:<10} {:<20} {:>10} {:<12} {}", fid, name, size_str, from, time);
-                    }
+        Commands::Files => match chat::list_files(room) {
+            Ok(files) => {
+                if files.is_empty() {
+                    println!("  (no files shared)");
+                    return;
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
+                println!(
+                    "  {:<10} {:<20} {:>10} {:<12} {}",
+                    "ID", "Filename", "Size", "From", "Time"
+                );
+                println!(
+                    "  {:<10} {:<20} {:>10} {:<12} {}",
+                    "─".repeat(10),
+                    "─".repeat(20),
+                    "─".repeat(10),
+                    "─".repeat(12),
+                    "─".repeat(8)
+                );
+                for f in &files {
+                    let fid = &f["file_id"].as_str().unwrap_or("?")
+                        [..6.min(f["file_id"].as_str().unwrap_or("?").len())];
+                    let name = f["filename"].as_str().unwrap_or("?");
+                    let size = f["size"].as_u64().unwrap_or(0);
+                    let from = f["from"].as_str().unwrap_or("?");
+                    let time = ts(f["ts"].as_u64().unwrap_or(0));
+                    let size_str = if size > 1024 {
+                        format!("{}KB", size / 1024)
+                    } else {
+                        format!("{}B", size)
+                    };
+                    println!(
+                        "  {:<10} {:<20} {:>10} {:<12} {}",
+                        fid, name, size_str, from, time
+                    );
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Download { file_id, out } => {
             match chat::download_file(&file_id, out.as_deref(), room) {
@@ -1918,83 +1995,78 @@ fn main() {
             }
         }
 
-        Commands::Daemon => {
-            match chat::daemon(room) {
-                Ok(pid) => {
-                    let daemon_room = if let Some(target) = room {
-                        store::find_room(target)
-                    } else {
-                        store::get_active_room()
-                    };
-                    if let Some(daemon_room) = daemon_room {
-                        println!(
-                            "  Daemon started (PID {pid}) for '{}'.\n  Notify flag: {}\n  Hook: agora notify --wake",
-                            daemon_room.label,
-                            store::notify_flag_path(&daemon_room.room_id).display()
-                        );
-                    } else {
-                        println!("  Daemon started (PID {pid}).\n  Hook: agora notify --wake");
-                    }
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
+        Commands::Daemon => match chat::daemon(room) {
+            Ok(pid) => {
+                let daemon_room = if let Some(target) = room {
+                    store::find_room(target)
+                } else {
+                    store::get_active_room()
+                };
+                if let Some(daemon_room) = daemon_room {
+                    println!(
+                        "  Daemon started (PID {pid}) for '{}'.\n  Notify flag: {}\n  Hook: agora notify --wake",
+                        daemon_room.label,
+                        store::notify_flag_path(&daemon_room.room_id).display()
+                    );
+                } else {
+                    println!("  Daemon started (PID {pid}).\n  Hook: agora notify --wake");
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Notify { wake } => {
-            match chat::notify("24h", room) {
-                Ok(msgs) => {
+        Commands::Notify { wake } => match chat::notify("24h", room) {
+            Ok(msgs) => {
+                if !msgs.is_empty() {
+                    for m in &msgs {
+                        print_msg(m);
+                    }
+                    if wake {
+                        process::exit(2);
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Stop => match chat::stop_daemon(room) {
+            Ok(()) => println!("  Daemon stopped."),
+            Err(e) => eprintln!("  {e}"),
+        },
+
+        Commands::Watch => match selected_room(room) {
+            Ok(watch_room) => {
+                println!(
+                    "  Watching '{}' (AES-256-GCM, Ctrl+C to stop)",
+                    watch_room.label
+                );
+                println!("  Auto-heartbeat every 2 minutes\n");
+                if let Ok(msgs) = chat::read("30m", 20, room) {
+                    for m in &msgs {
+                        print_msg(m);
+                    }
                     if !msgs.is_empty() {
-                        for m in &msgs {
-                            print_msg(m);
-                        }
-                        if wake {
-                            process::exit(2);
-                        }
+                        println!("  ─── live ───\n");
                     }
                 }
-                Err(e) => {
+                if let Err(e) = chat::watch(room, 120, |env| {
+                    print_msg(env);
+                }) {
                     eprintln!("  Error: {e}");
                     process::exit(1);
                 }
             }
-        }
-
-        Commands::Stop => {
-            match chat::stop_daemon(room) {
-                Ok(()) => println!("  Daemon stopped."),
-                Err(e) => eprintln!("  {e}"),
+            Err(e) => {
+                eprintln!("  {e}");
+                process::exit(1);
             }
-        }
-
-        Commands::Watch => {
-            match selected_room(room) {
-                Ok(watch_room) => {
-                    println!("  Watching '{}' (AES-256-GCM, Ctrl+C to stop)", watch_room.label);
-                    println!("  Auto-heartbeat every 2 minutes\n");
-                    if let Ok(msgs) = chat::read("30m", 20, room) {
-                        for m in &msgs {
-                            print_msg(m);
-                        }
-                        if !msgs.is_empty() {
-                            println!("  ─── live ───\n");
-                        }
-                    }
-                    if let Err(e) = chat::watch(room, 120, |env| {
-                        print_msg(env);
-                    }) {
-                        eprintln!("  Error: {e}");
-                        process::exit(1);
-                    }
-                }
-                Err(e) => {
-                    eprintln!("  {e}");
-                    process::exit(1);
-                }
-            }
-        }
+        },
 
         Commands::Hub { log } => {
             let active_room = match selected_room(room) {
@@ -2056,7 +2128,9 @@ fn main() {
                 });
 
                 // SSE disconnected — reconnect
-                eprintln!("  \x1b[33m[hub] Connection lost. Reconnecting in 5s... ({msg_count} messages received so far)\x1b[0m");
+                eprintln!(
+                    "  \x1b[33m[hub] Connection lost. Reconnecting in 5s... ({msg_count} messages received so far)\x1b[0m"
+                );
                 std::thread::sleep(std::time::Duration::from_secs(5));
             }
         }
@@ -2067,8 +2141,7 @@ fn main() {
 
         Commands::Status { json } => {
             let agent_id = store::get_agent_id();
-            let (credits, trust_ledger) = chat::credit_balance_check(None, room)
-                .unwrap_or((0, 0));
+            let (credits, trust_ledger) = chat::credit_balance_check(None, room).unwrap_or((0, 0));
             let (trust_score, receipt_count, rooms_active, vouches) =
                 chat::compute_agent_trust_score(&agent_id);
             let receipts = chat::read_status(room).unwrap_or_default();
@@ -2091,13 +2164,24 @@ fn main() {
                     return;
                 }
                 for item in &receipts {
-                    let mid = &item["id"].as_str().unwrap_or("?")[..6.min(item["id"].as_str().unwrap_or("?").len())];
+                    let mid = &item["id"].as_str().unwrap_or("?")
+                        [..6.min(item["id"].as_str().unwrap_or("?").len())];
                     let text = item["text"].as_str().unwrap_or("");
                     let time = ts(item["ts"].as_u64().unwrap_or(0));
-                    let readers = item["read_by"].as_array()
-                        .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(", "))
+                    let readers = item["read_by"]
+                        .as_array()
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|v| v.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        })
                         .unwrap_or_default();
-                    let check = if readers.is_empty() { "  " } else { "\u{2713}\u{2713}" };
+                    let check = if readers.is_empty() {
+                        "  "
+                    } else {
+                        "\u{2713}\u{2713}"
+                    };
                     println!("  [{mid}] {time} {check} {text}");
                     if !readers.is_empty() {
                         println!("         Read by: {readers}");
@@ -2106,15 +2190,20 @@ fn main() {
             }
         }
 
-        Commands::CreditGrant { agent_id, amount, reason } => {
-            match chat::credit_grant(&agent_id, amount, &reason, room) {
-                Ok(balance) => {
-                    let name = resolve_display_name(&agent_id);
-                    println!("  Granted {amount} credits to {name}. Balance: {balance}");
-                }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::CreditGrant {
+            agent_id,
+            amount,
+            reason,
+        } => match chat::credit_grant(&agent_id, amount, &reason, room) {
+            Ok(balance) => {
+                let name = resolve_display_name(&agent_id);
+                println!("  Granted {amount} credits to {name}. Balance: {balance}");
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Balance { agent_id } => {
             match chat::credit_balance_check(agent_id.as_deref(), room) {
@@ -2124,51 +2213,82 @@ fn main() {
                     println!("  {name}:");
                     println!("    Credits (spendable): {credits}");
                     println!("    Trust (ledger):      {trust}");
-                    let (score, receipt_count, rooms_active, vouches) = chat::compute_agent_trust_score(&id);
-                    println!("    Trust (live score):  {score:.2}  [{receipt_count} receipts, {rooms_active} rooms, {vouches} vouches]");
+                    let (score, receipt_count, rooms_active, vouches) =
+                        chat::compute_agent_trust_score(&id);
+                    println!(
+                        "    Trust (live score):  {score:.2}  [{receipt_count} receipts, {rooms_active} rooms, {vouches} vouches]"
+                    );
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
         Commands::Bet { question } => {
             let q = question.join(" ");
             match chat::bet_create(&q, room) {
-                Ok(id) => println!("  Bet [{id}] created: {q}\n  Stake with: agora stake {id} <amount> --yes/--no", id = &id[..6.min(id.len())]),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Stake { bet_id, amount, yes } => {
-            match chat::bet_stake(&bet_id, yes, amount, room) {
-                Ok(()) => println!("  Staked {amount} on {} (bet {bet_id})", if yes {"YES"} else {"NO"}),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Resolve { bet_id, yes } => {
-            match chat::bet_resolve(&bet_id, yes, room) {
-                Ok(msg) => println!("  {msg}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Bets => {
-            match chat::bet_list(room) {
-                Ok(bets) => {
-                    let open: Vec<_> = bets.iter().filter(|b| b.status == "open").collect();
-                    if open.is_empty() { println!("  No open bets."); return; }
-                    println!("  {} open bet(s):\n", open.len());
-                    for b in &open {
-                        let yes_total: i64 = b.stakes_yes.iter().map(|(_, a)| a).sum();
-                        let no_total: i64 = b.stakes_no.iter().map(|(_, a)| a).sum();
-                        println!("  [{}] {} (YES: {} | NO: {} | by {})",
-                            &b.id[..6.min(b.id.len())], b.question, yes_total, no_total, b.created_by);
-                    }
+                Ok(id) => println!(
+                    "  Bet [{id}] created: {q}\n  Stake with: agora stake {id} <amount> --yes/--no",
+                    id = &id[..6.min(id.len())]
+                ),
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
         }
+
+        Commands::Stake {
+            bet_id,
+            amount,
+            yes,
+        } => match chat::bet_stake(&bet_id, yes, amount, room) {
+            Ok(()) => println!(
+                "  Staked {amount} on {} (bet {bet_id})",
+                if yes { "YES" } else { "NO" }
+            ),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Resolve { bet_id, yes } => match chat::bet_resolve(&bet_id, yes, room) {
+            Ok(msg) => println!("  {msg}"),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Bets => match chat::bet_list(room) {
+            Ok(bets) => {
+                let open: Vec<_> = bets.iter().filter(|b| b.status == "open").collect();
+                if open.is_empty() {
+                    println!("  No open bets.");
+                    return;
+                }
+                println!("  {} open bet(s):\n", open.len());
+                for b in &open {
+                    let yes_total: i64 = b.stakes_yes.iter().map(|(_, a)| a).sum();
+                    let no_total: i64 = b.stakes_no.iter().map(|(_, a)| a).sum();
+                    println!(
+                        "  [{}] {} (YES: {} | NO: {} | by {})",
+                        &b.id[..6.min(b.id.len())],
+                        b.question,
+                        yes_total,
+                        no_total,
+                        b.created_by
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::SandboxKey { hours } => {
             let agent_id = store::get_agent_id();
@@ -2177,10 +2297,17 @@ fn main() {
             if let Some(r) = room.and_then(|l| store::find_room(l)) {
                 let balance = store::credit_balance(&r.room_id, &agent_id);
                 if balance < cost {
-                    eprintln!("  Insufficient credits: have {balance}, need {cost} for {hours}h sandbox access.");
+                    eprintln!(
+                        "  Insufficient credits: have {balance}, need {cost} for {hours}h sandbox access."
+                    );
                     process::exit(1);
                 }
-                store::credit_add(&r.room_id, &agent_id, -cost, &format!("sandbox key: {hours}h access"));
+                store::credit_add(
+                    &r.room_id,
+                    &agent_id,
+                    -cost,
+                    &format!("sandbox key: {hours}h access"),
+                );
             }
             let token = sandbox::generate_agent_token(&agent_id, hours);
             println!("  Sandbox access token ({hours}h):");
@@ -2197,18 +2324,24 @@ fn main() {
             // Bounded debt: check credit balance before provisioning
             let max_session_cost: i64 = 50; // max credits per sandbox session
             // Bug fix: also check active room, not just --room flag
-            let active = room.and_then(|l| store::find_room(l)).or_else(|| store::get_active_room());
+            let active = room
+                .and_then(|l| store::find_room(l))
+                .or_else(|| store::get_active_room());
             if let Some(r) = active {
                 let balance = store::credit_balance(&r.room_id, &agent_id);
                 if balance < max_session_cost {
-                    eprintln!("  Insufficient credits: have {balance}, need {max_session_cost} for sandbox.");
+                    eprintln!(
+                        "  Insufficient credits: have {balance}, need {max_session_cost} for sandbox."
+                    );
                     eprintln!("  Earn credits by completing bounties or funding your balance.");
                     process::exit(1);
                 }
                 // Check for existing open lease
                 let session_file = store::agora_dir().join("sandbox_session.json");
                 if session_file.exists() {
-                    eprintln!("  You already have an active sandbox. Destroy it first: agora sandbox-destroy <id>");
+                    eprintln!(
+                        "  You already have an active sandbox. Destroy it first: agora sandbox-destroy <id>"
+                    );
                     process::exit(1);
                 }
             }
@@ -2220,45 +2353,61 @@ fn main() {
                     println!("  Run: agora sandbox-exec <command>");
                     // Save session for later use
                     let session_file = store::agora_dir().join("sandbox_session.json");
-                    let _ = std::fs::write(&session_file, serde_json::to_string_pretty(&session).unwrap());
+                    let _ = std::fs::write(
+                        &session_file,
+                        serde_json::to_string_pretty(&session).unwrap(),
+                    );
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
         Commands::SandboxExec { command } => {
             let cmd = command.join(" ");
             let session_file = store::agora_dir().join("sandbox_session.json");
-            let session: sandbox::SandboxSession = serde_json::from_str(
-                &std::fs::read_to_string(&session_file).unwrap_or_default()
-            ).map_err(|_| "No active sandbox. Run: agora sandbox-create").unwrap();
+            let session: sandbox::SandboxSession =
+                serde_json::from_str(&std::fs::read_to_string(&session_file).unwrap_or_default())
+                    .map_err(|_| "No active sandbox. Run: agora sandbox-create")
+                    .unwrap();
             match sandbox::exec(&session.id, &cmd, &session.provider) {
                 Ok(output) => println!("{output}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
         Commands::SandboxDestroy { session_id } => {
             let session_file = store::agora_dir().join("sandbox_session.json");
-            let session: sandbox::SandboxSession = serde_json::from_str(
-                &std::fs::read_to_string(&session_file).unwrap_or_default()
-            ).unwrap_or_else(|_| sandbox::SandboxSession {
-                id: session_id.clone(), provider: "e2b".to_string(),
-                agent_id: String::new(), created_at: 0, status: "unknown".to_string(),
-            });
+            let session: sandbox::SandboxSession =
+                serde_json::from_str(&std::fs::read_to_string(&session_file).unwrap_or_default())
+                    .unwrap_or_else(|_| sandbox::SandboxSession {
+                        id: session_id.clone(),
+                        provider: "e2b".to_string(),
+                        agent_id: String::new(),
+                        created_at: 0,
+                        status: "unknown".to_string(),
+                    });
             match sandbox::destroy(&session.id, &session.provider) {
                 Ok(()) => {
                     let _ = std::fs::remove_file(&session_file);
                     println!("  Sandbox destroyed.");
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
         Commands::SandboxAudit => {
             let me = store::get_agent_id();
-            let room_filter = room
-                .and_then(|label| store::find_room(label).map(|entry| entry.room_id));
+            let room_filter =
+                room.and_then(|label| store::find_room(label).map(|entry| entry.room_id));
             let records: Vec<_> = store::load_sandbox_audit()
                 .into_iter()
                 .filter(|record| record.agent_id == me)
@@ -2317,16 +2466,20 @@ fn main() {
                     println!("  Sent {amount} credits to {name}.");
                     println!("  Your balance: {my_bal} | Their balance: {their_bal}");
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::Gap { gap_type, urgency } => {
-            match chat::gap_emit(&gap_type, urgency, room) {
-                Ok(id) => println!("  Gap [{id}] emitted: seeking {gap_type} (urgency {urgency}/5)"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::Gap { gap_type, urgency } => match chat::gap_emit(&gap_type, urgency, room) {
+            Ok(id) => println!("  Gap [{id}] emitted: seeking {gap_type} (urgency {urgency}/5)"),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
         Commands::Gaps => {
             let gaps = chat::gap_list();
@@ -2335,43 +2488,81 @@ fn main() {
                 return;
             }
             println!("  {} gap(s):\n", gaps.len());
-            let now_ts = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+            let now_ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
             for g in &gaps {
                 let age = now_ts.saturating_sub(g.since);
-                let age_str = if age < 3600 { format!("{}m", age / 60) } else { format!("{}h", age / 3600) };
-                println!("  [{:<16}] P{} {} — {} tasks blocked, open {age_str} ({})",
-                    g.gap_type, g.urgency, g.room_label, g.blocked_tasks, g.room_label);
+                let age_str = if age < 3600 {
+                    format!("{}m", age / 60)
+                } else {
+                    format!("{}h", age / 3600)
+                };
+                println!(
+                    "  [{:<16}] P{} {} — {} tasks blocked, open {age_str} ({})",
+                    g.gap_type, g.urgency, g.room_label, g.blocked_tasks, g.room_label
+                );
             }
         }
 
-        Commands::Directory => {
-            match chat::directory() {
-                Ok(rooms) => {
-                    if rooms.is_empty() {
-                        println!("  No rooms. Create one: agora create <name>");
-                        return;
-                    }
-                    println!("  {:<16} {:<6} {:<6} {:<12} Topic", "Room", "Online", "Msgs", "Last Active");
-                    println!("  {:<16} {:<6} {:<6} {:<12} {}", "─".repeat(16), "─".repeat(6), "─".repeat(6), "─".repeat(12), "─".repeat(20));
-                    let now_ts = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-                    for r in &rooms {
-                        let ago = if r.last_activity > 0 {
-                            let d = now_ts.saturating_sub(r.last_activity);
-                            if d < 60 { format!("{d}s ago") }
-                            else if d < 3600 { format!("{}m ago", d / 60) }
-                            else { format!("{}h ago", d / 3600) }
-                        } else { "never".to_string() };
-                        let topic = r.topic.as_deref().unwrap_or("");
-                        let short_topic = &topic[..40.min(topic.len())];
-                        println!("  {:<16} {:<6} {:<6} {:<12} {}", r.label, r.agent_count, r.message_count, ago, short_topic);
-                    }
+        Commands::Directory => match chat::directory() {
+            Ok(rooms) => {
+                if rooms.is_empty() {
+                    println!("  No rooms. Create one: agora create <name>");
+                    return;
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                println!(
+                    "  {:<16} {:<6} {:<6} {:<12} Topic",
+                    "Room", "Online", "Msgs", "Last Active"
+                );
+                println!(
+                    "  {:<16} {:<6} {:<6} {:<12} {}",
+                    "─".repeat(16),
+                    "─".repeat(6),
+                    "─".repeat(6),
+                    "─".repeat(12),
+                    "─".repeat(20)
+                );
+                let now_ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                for r in &rooms {
+                    let ago = if r.last_activity > 0 {
+                        let d = now_ts.saturating_sub(r.last_activity);
+                        if d < 60 {
+                            format!("{d}s ago")
+                        } else if d < 3600 {
+                            format!("{}m ago", d / 60)
+                        } else {
+                            format!("{}h ago", d / 3600)
+                        }
+                    } else {
+                        "never".to_string()
+                    };
+                    let topic = r.topic.as_deref().unwrap_or("");
+                    let short_topic = &topic[..40.min(topic.len())];
+                    println!(
+                        "  {:<16} {:<6} {:<6} {:<12} {}",
+                        r.label, r.agent_count, r.message_count, ago, short_topic
+                    );
+                }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Card { capabilities, description } => {
-            let caps: Vec<String> = capabilities.split(',').map(|s| s.trim().to_string()).collect();
+        Commands::Card {
+            capabilities,
+            description,
+        } => {
+            let caps: Vec<String> = capabilities
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .collect();
             match chat::card_set(&caps, description.as_deref(), room) {
                 Ok(()) => {
                     println!("  Card published: {}", caps.join(", "));
@@ -2379,27 +2570,37 @@ fn main() {
                         println!("  Description: {desc}");
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::CardShow { agent_id } => {
-            match chat::card_show(agent_id.as_deref(), room) {
-                Ok(Some(card)) => {
-                    let name = resolve_display_name(&card.agent_id);
-                    println!("  {name}");
-                    println!("  Capabilities: {}", card.capabilities.join(", "));
-                    if let Some(desc) = &card.description {
-                        println!("  Description: {desc}");
-                    }
-                    println!("  Available: {}", if card.available { "yes" } else { "no" });
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
                 }
-                Ok(None) => println!("  No card found."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
         }
 
-        Commands::Bounty { title, priority, oracle, reward, deadline } => {
+        Commands::CardShow { agent_id } => match chat::card_show(agent_id.as_deref(), room) {
+            Ok(Some(card)) => {
+                let name = resolve_display_name(&card.agent_id);
+                println!("  {name}");
+                println!("  Capabilities: {}", card.capabilities.join(", "));
+                if let Some(desc) = &card.description {
+                    println!("  Description: {desc}");
+                }
+                println!("  Available: {}", if card.available { "yes" } else { "no" });
+            }
+            Ok(None) => println!("  No card found."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Bounty {
+            title,
+            priority,
+            oracle,
+            reward,
+            deadline,
+        } => {
             let t = title.join(" ");
             let oracle_ref = oracle.as_deref();
             match chat::bounty_post(&t, priority, oracle_ref, reward, deadline, room) {
@@ -2415,144 +2616,174 @@ fn main() {
                         println!("  Deadline: {h}h (auto-expires and refunds at deadline)");
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::BountyExpire => {
-            match chat::bounty_expire_check(room) {
-                Ok(expired) => {
-                    if expired.is_empty() {
-                        println!("  No expired bounties found.");
-                    } else {
-                        println!("  Expired {} bounty(s):", expired.len());
-                        for id in &expired {
-                            println!("  [{id}] — credits refunded to poster");
-                        }
+        Commands::BountyExpire => match chat::bounty_expire_check(room) {
+            Ok(expired) => {
+                if expired.is_empty() {
+                    println!("  No expired bounties found.");
+                } else {
+                    println!("  Expired {} bounty(s):", expired.len());
+                    for id in &expired {
+                        println!("  [{id}] — credits refunded to poster");
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::BountySubmit { task_id, branch } => {
             match chat::bounty_submit(&task_id, &branch, room) {
                 Ok(msg) => println!("  {msg}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
         Commands::BountyVerify { task_id, agent_id } => {
             match chat::bounty_verify(&task_id, &agent_id, room) {
                 Ok(msg) => println!("  {msg}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::Bounties => {
-            match chat::bounty_list(room) {
-                Ok(bounties) => {
-                    if bounties.is_empty() {
-                        println!("  No open bounties.");
-                        return;
-                    }
-                    println!("  {} open bounties:\n", bounties.len());
-                    let now_ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    for b in &bounties {
-                        let id = &b["id"].as_str().unwrap_or("?")[..6.min(b["id"].as_str().unwrap_or("?").len())];
-                        let title = b["title"].as_str().unwrap_or("?");
-                        let priority = b["priority"].as_u64().unwrap_or(0);
-                        let from = b["from"].as_str().unwrap_or("?");
-                        let deadline_str = if let Some(exp) = b["expires_at"].as_u64() {
-                            if exp > now_ts {
-                                let secs_left = exp - now_ts;
-                                let hours_left = secs_left / 3600;
-                                let mins_left = (secs_left % 3600) / 60;
-                                format!(", expires in {hours_left}h{mins_left}m")
-                            } else {
-                                ", EXPIRED".to_string()
-                            }
+        Commands::Bounties => match chat::bounty_list(room) {
+            Ok(bounties) => {
+                if bounties.is_empty() {
+                    println!("  No open bounties.");
+                    return;
+                }
+                println!("  {} open bounties:\n", bounties.len());
+                let now_ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                for b in &bounties {
+                    let id = &b["id"].as_str().unwrap_or("?")
+                        [..6.min(b["id"].as_str().unwrap_or("?").len())];
+                    let title = b["title"].as_str().unwrap_or("?");
+                    let priority = b["priority"].as_u64().unwrap_or(0);
+                    let from = b["from"].as_str().unwrap_or("?");
+                    let deadline_str = if let Some(exp) = b["expires_at"].as_u64() {
+                        if exp > now_ts {
+                            let secs_left = exp - now_ts;
+                            let hours_left = secs_left / 3600;
+                            let mins_left = (secs_left % 3600) / 60;
+                            format!(", expires in {hours_left}h{mins_left}m")
                         } else {
-                            String::new()
-                        };
-                        println!("  [{id}] P{priority} {title} (by {from}{deadline_str})");
-                    }
+                            ", EXPIRED".to_string()
+                        }
+                    } else {
+                        String::new()
+                    };
+                    println!("  [{id}] P{priority} {title} (by {from}{deadline_str})");
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
-        }
-
-        Commands::Fund { credits, tx } => {
-            match (credits, tx.as_deref()) {
-                (Some(_), Some(_)) => {
-                    eprintln!("  Error: choose either Stripe checkout credits or --tx, not both.");
-                    process::exit(1);
-                }
-                (None, None) => {
-                    eprintln!("  Usage: agora fund <credits> OR agora fund --tx <solana-signature>");
-                    process::exit(1);
-                }
-                (_, Some(signature)) => match chat::payment_fund_via_tx(signature, room) {
-                    Ok(msg) => println!("  {msg}"),
-                    Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-                },
-                (Some(credits), None) => match chat::payment_fund(credits, room) {
-                    Ok(checkout_url) => {
-                        let amount_usd = (credits / store::CREDITS_PER_USD_CENT) as f64 / 100.0;
-                        println!("  Stripe Checkout created for {credits} credits (${:.2}).", amount_usd);
-                        println!("  Complete payment at:");
-                        println!("  {checkout_url}");
-                        println!();
-                        println!("  Credits will be minted after payment confirmation.");
-                        println!("  10% platform fee applies — you receive {} credits net.", credits - credits / 10);
-                    }
-                    Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-                },
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::Withdraw { credits } => {
-            match chat::payment_withdraw(credits, room) {
+        Commands::Fund { credits, tx } => match (credits, tx.as_deref()) {
+            (Some(_), Some(_)) => {
+                eprintln!("  Error: choose either Stripe checkout credits or --tx, not both.");
+                process::exit(1);
+            }
+            (None, None) => {
+                eprintln!("  Usage: agora fund <credits> OR agora fund --tx <solana-signature>");
+                process::exit(1);
+            }
+            (_, Some(signature)) => match chat::payment_fund_via_tx(signature, room) {
                 Ok(msg) => println!("  {msg}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Payments => {
-            match chat::payment_history(room) {
-                Ok(records) => {
-                    if records.is_empty() {
-                        println!("  No payment history.");
-                        return;
-                    }
-                    println!("  Payment history ({} records):\n", records.len());
-                    for r in &records {
-                        let kind = match r.kind {
-                            store::PaymentKind::Deposit => "deposit",
-                            store::PaymentKind::Withdrawal => "withdrawal",
-                        };
-                        let status = match r.status {
-                            store::PaymentStatus::Pending => "pending",
-                            store::PaymentStatus::Completed => "completed",
-                            store::PaymentStatus::Failed => "failed",
-                            store::PaymentStatus::Refunded => "refunded",
-                        };
-                        let amount_usd = r.amount_cents as f64 / 100.0;
-                        println!(
-                            "  [{}] {} {} — {} credits (${:.2}) — {}",
-                            &r.id[..8.min(r.id.len())],
-                            kind, status,
-                            r.credits, amount_usd,
-                            if r.checkout_url.is_some() { "awaiting payment" } else { "" }
-                        );
-                    }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+            },
+            (Some(credits), None) => match chat::payment_fund(credits, room) {
+                Ok(checkout_url) => {
+                    let amount_usd = (credits / store::CREDITS_PER_USD_CENT) as f64 / 100.0;
+                    println!(
+                        "  Stripe Checkout created for {credits} credits (${:.2}).",
+                        amount_usd
+                    );
+                    println!("  Complete payment at:");
+                    println!("  {checkout_url}");
+                    println!();
+                    println!("  Credits will be minted after payment confirmation.");
+                    println!(
+                        "  10% platform fee applies — you receive {} credits net.",
+                        credits - credits / 10
+                    );
+                }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
+            },
+        },
+
+        Commands::Withdraw { credits } => match chat::payment_withdraw(credits, room) {
+            Ok(msg) => println!("  {msg}"),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
+
+        Commands::Payments => match chat::payment_history(room) {
+            Ok(records) => {
+                if records.is_empty() {
+                    println!("  No payment history.");
+                    return;
+                }
+                println!("  Payment history ({} records):\n", records.len());
+                for r in &records {
+                    let kind = match r.kind {
+                        store::PaymentKind::Deposit => "deposit",
+                        store::PaymentKind::Withdrawal => "withdrawal",
+                    };
+                    let status = match r.status {
+                        store::PaymentStatus::Pending => "pending",
+                        store::PaymentStatus::Completed => "completed",
+                        store::PaymentStatus::Failed => "failed",
+                        store::PaymentStatus::Refunded => "refunded",
+                    };
+                    let amount_usd = r.amount_cents as f64 / 100.0;
+                    println!(
+                        "  [{}] {} {} — {} credits (${:.2}) — {}",
+                        &r.id[..8.min(r.id.len())],
+                        kind,
+                        status,
+                        r.credits,
+                        amount_usd,
+                        if r.checkout_url.is_some() {
+                            "awaiting payment"
+                        } else {
+                            ""
+                        }
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Vouch { agent_id, reason } => {
             match chat::vouch(&agent_id, reason.as_deref(), room) {
@@ -2560,208 +2791,277 @@ fn main() {
                     let name = resolve_display_name(&agent_id);
                     println!("  Vouched for {name}.");
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::Discover { need } => {
-            match chat::discover(&need, room) {
-                Ok(results) => {
-                    if results.is_empty() {
-                        println!("  No agents found matching: {need}");
-                        return;
-                    }
-                    println!("  {} agent(s) matching '{need}':\n", results.len());
-                    for r in &results {
-                        let name = resolve_display_name(&r.card.agent_id);
-                        let desc = r.card.description.as_deref().unwrap_or("");
-                        let trust = format!("{:.1}", r.trust_score);
-                        let abandonment = format!("{:.0}%", r.abandonment_rate * 100.0);
-                        let volatility = format!("{:.0}%", r.volatility_score * 100.0);
-                        println!(
-                            "  {name} — {} (trust: {trust}, receipts: {}, rooms: {}, stale: {}, abandonment: {abandonment}, volatility: {volatility})",
-                            r.card.capabilities.join(", "),
-                            r.receipt_count,
-                            r.rooms_active,
-                            r.stale_claims,
-                        );
-                        if !desc.is_empty() { println!("    {desc}"); }
+        Commands::Discover { need } => match chat::discover(&need, room) {
+            Ok(results) => {
+                if results.is_empty() {
+                    println!("  No agents found matching: {need}");
+                    return;
+                }
+                println!("  {} agent(s) matching '{need}':\n", results.len());
+                for r in &results {
+                    let name = resolve_display_name(&r.card.agent_id);
+                    let desc = r.card.description.as_deref().unwrap_or("");
+                    let trust = format!("{:.1}", r.trust_score);
+                    let abandonment = format!("{:.0}%", r.abandonment_rate * 100.0);
+                    let volatility = format!("{:.0}%", r.volatility_score * 100.0);
+                    println!(
+                        "  {name} — {} (trust: {trust}, receipts: {}, rooms: {}, stale: {}, abandonment: {abandonment}, volatility: {volatility})",
+                        r.card.capabilities.join(", "),
+                        r.receipt_count,
+                        r.rooms_active,
+                        r.stale_claims,
+                    );
+                    if !desc.is_empty() {
+                        println!("    {desc}");
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::SomaAssert { subject, predicate, confidence, git_ref } => {
+        Commands::SomaAssert {
+            subject,
+            predicate,
+            confidence,
+            git_ref,
+        } => {
             let pred = predicate.join(" ");
             match chat::soma_assert(&subject, &pred, Some(confidence), git_ref.as_deref(), room) {
                 Ok(id) => println!("  Belief [{id}] asserted: {subject}: {pred}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::SomaQuery { subject } => {
-            match chat::soma_query(&subject, room) {
-                Ok(beliefs) => {
-                    if beliefs.is_empty() {
-                        println!("  No beliefs about '{subject}'.");
-                        return;
-                    }
-                    println!("  {} belief(s) about '{subject}':\n", beliefs.len());
-                    for b in &beliefs {
-                        let bid = &b["id"].as_str().unwrap_or("?")[..6.min(b["id"].as_str().unwrap_or("?").len())];
-                        let btype = if b["type"].as_str() == Some("soma_correction") { "CORRECTED" } else { "belief" };
-                        let pred = b["predicate"].as_str().unwrap_or("?");
-                        let from = b["from"].as_str().unwrap_or("?");
-                        let name = resolve_display_name(from);
-                        println!("  [{bid}] ({btype}) {pred}");
-                        println!("         by {name}");
-                        print_soma_details(b);
-                    }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
         }
 
-        Commands::SomaCorrect { belief_id, predicate, reason } => {
+        Commands::SomaQuery { subject } => match chat::soma_query(&subject, room) {
+            Ok(beliefs) => {
+                if beliefs.is_empty() {
+                    println!("  No beliefs about '{subject}'.");
+                    return;
+                }
+                println!("  {} belief(s) about '{subject}':\n", beliefs.len());
+                for b in &beliefs {
+                    let bid = &b["id"].as_str().unwrap_or("?")
+                        [..6.min(b["id"].as_str().unwrap_or("?").len())];
+                    let btype = if b["type"].as_str() == Some("soma_correction") {
+                        "CORRECTED"
+                    } else {
+                        "belief"
+                    };
+                    let pred = b["predicate"].as_str().unwrap_or("?");
+                    let from = b["from"].as_str().unwrap_or("?");
+                    let name = resolve_display_name(from);
+                    println!("  [{bid}] ({btype}) {pred}");
+                    println!("         by {name}");
+                    print_soma_details(b);
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::SomaCorrect {
+            belief_id,
+            predicate,
+            reason,
+        } => {
             let pred = predicate.join(" ");
             match chat::soma_correct(&belief_id, &pred, reason.as_deref(), room) {
                 Ok(id) => println!("  Correction [{id}] recorded. Subscribers notified."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::SeedGen => {
-            match chat::seed_gen(room) {
-                Ok((id, puzzle)) => {
-                    println!("  Calibration seed [{id_short}] created.", id_short = &id[..8]);
-                    println!("  Puzzle: {puzzle}");
-                    println!("  Solve with: agora seed-verify {id_short} <answer>", id_short = &id[..8]);
-                }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::SeedGen => match chat::seed_gen(room) {
+            Ok((id, puzzle)) => {
+                println!(
+                    "  Calibration seed [{id_short}] created.",
+                    id_short = &id[..8]
+                );
+                println!("  Puzzle: {puzzle}");
+                println!(
+                    "  Solve with: agora seed-verify {id_short} <answer>",
+                    id_short = &id[..8]
+                );
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::SeedVerify { seed_id, answer } => {
             let ans = answer.join(" ");
-            if ans.is_empty() { eprintln!("Usage: agora seed-verify <seed-id> <answer>"); process::exit(1); }
+            if ans.is_empty() {
+                eprintln!("Usage: agora seed-verify <seed-id> <answer>");
+                process::exit(1);
+            }
             match chat::seed_verify(&seed_id, &ans, room) {
-                Ok(true) => println!("  Correct! Work receipt issued. Your trust score has been updated."),
+                Ok(true) => {
+                    println!("  Correct! Work receipt issued. Your trust score has been updated.")
+                }
                 Ok(false) => println!("  Incorrect answer. Try again."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::Seeds => {
-            match chat::seed_list(room) {
-                Ok(seeds) => {
-                    if seeds.is_empty() {
-                        println!("  (no calibration seeds — use 'agora seed-gen' to create one)");
-                        return;
-                    }
-                    println!("  Calibration Seeds ({}):", seeds.len());
-                    for s in &seeds {
-                        let solvers = if s.solved_by.is_empty() {
-                            "unsolved".to_string()
-                        } else {
-                            format!("solved by {} agent(s)", s.solved_by.len())
-                        };
-                        println!(
-                            "    [{id_short}] [{diff}] {title} — {solvers}",
-                            id_short = &s.id[..8.min(s.id.len())],
-                            diff = s.difficulty,
-                            title = s.title
-                        );
-                        println!("           Puzzle: {}", s.puzzle);
-                    }
+        Commands::Seeds => match chat::seed_list(room) {
+            Ok(seeds) => {
+                if seeds.is_empty() {
+                    println!("  (no calibration seeds — use 'agora seed-gen' to create one)");
+                    return;
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                println!("  Calibration Seeds ({}):", seeds.len());
+                for s in &seeds {
+                    let solvers = if s.solved_by.is_empty() {
+                        "unsolved".to_string()
+                    } else {
+                        format!("solved by {} agent(s)", s.solved_by.len())
+                    };
+                    println!(
+                        "    [{id_short}] [{diff}] {title} — {solvers}",
+                        id_short = &s.id[..8.min(s.id.len())],
+                        diff = s.difficulty,
+                        title = s.title
+                    );
+                    println!("           Puzzle: {}", s.puzzle);
+                }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::TaskAdd { title } => {
             let t = title.join(" ");
-            if t.is_empty() { eprintln!("Usage: agora task-add <title>"); process::exit(1); }
+            if t.is_empty() {
+                eprintln!("Usage: agora task-add <title>");
+                process::exit(1);
+            }
             match chat::task_add(&t, room) {
                 Ok(id) => println!("  Task [{id}] created: {t}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::TaskClaim { task_id } => {
-            match chat::task_claim(&task_id, room) {
-                Ok(id) => println!("  Claimed task [{id}]."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::TaskClaim { task_id } => match chat::task_claim(&task_id, room) {
+            Ok(id) => println!("  Claimed task [{id}]."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
         Commands::TaskDone { task_id, notes } => {
             match chat::task_done(&task_id, notes.as_deref(), room) {
                 Ok(id) => println!("  Task [{id}] marked done."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
         Commands::TaskCheckpoint { task_id, notes } => {
             match chat::task_checkpoint(&task_id, notes.as_deref(), room) {
                 Ok(id) => println!("  Task [{id}] checkpoint recorded."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
         Commands::TaskReject { task_id, notes } => {
             match chat::task_reject(&task_id, notes.as_deref(), room) {
                 Ok(id) => println!("  Task [{id}] rejected and returned to the pool."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::Tasks => {
-            match chat::task_list(room) {
-                Ok(tasks) => {
-                    if tasks.is_empty() {
-                        println!("  (no tasks)");
-                        return;
-                    }
-                    let open: Vec<_> = tasks.iter().filter(|t| t.status == "open").collect();
-                    let claimed: Vec<_> = tasks.iter().filter(|t| t.status == "claimed").collect();
-                    let done: Vec<_> = tasks.iter().filter(|t| t.status == "done").collect();
+        Commands::Tasks => match chat::task_list(room) {
+            Ok(tasks) => {
+                if tasks.is_empty() {
+                    println!("  (no tasks)");
+                    return;
+                }
+                let open: Vec<_> = tasks.iter().filter(|t| t.status == "open").collect();
+                let claimed: Vec<_> = tasks.iter().filter(|t| t.status == "claimed").collect();
+                let done: Vec<_> = tasks.iter().filter(|t| t.status == "done").collect();
 
-                    if !open.is_empty() {
-                        println!("  Open ({}):", open.len());
-                        for t in &open {
-                            println!("    [{}] {}", &t.id[..6.min(t.id.len())], t.title);
-                        }
-                    }
-                    if !claimed.is_empty() {
-                        println!("  In Progress ({}):", claimed.len());
-                        for t in &claimed {
-                            let by = t.claimed_by.as_deref().unwrap_or("?");
-                            let name = resolve_display_name(by);
-                            let note = t.notes.as_deref().unwrap_or("");
-                            println!(
-                                "    [{}] {} (by {name}){}",
-                                &t.id[..6.min(t.id.len())],
-                                t.title,
-                                if note.is_empty() {
-                                    String::new()
-                                } else {
-                                    format!(" — {note}")
-                                }
-                            );
-                        }
-                    }
-                    if !done.is_empty() {
-                        println!("  Done ({}):", done.len());
-                        for t in &done {
-                            let note = t.notes.as_deref().unwrap_or("");
-                            println!("    [{}] {} {}", &t.id[..6.min(t.id.len())], t.title, if note.is_empty() { String::new() } else { format!("— {note}") });
-                        }
+                if !open.is_empty() {
+                    println!("  Open ({}):", open.len());
+                    for t in &open {
+                        println!("    [{}] {}", &t.id[..6.min(t.id.len())], t.title);
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                if !claimed.is_empty() {
+                    println!("  In Progress ({}):", claimed.len());
+                    for t in &claimed {
+                        let by = t.claimed_by.as_deref().unwrap_or("?");
+                        let name = resolve_display_name(by);
+                        let note = t.notes.as_deref().unwrap_or("");
+                        println!(
+                            "    [{}] {} (by {name}){}",
+                            &t.id[..6.min(t.id.len())],
+                            t.title,
+                            if note.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" — {note}")
+                            }
+                        );
+                    }
+                }
+                if !done.is_empty() {
+                    println!("  Done ({}):", done.len());
+                    for t in &done {
+                        let note = t.notes.as_deref().unwrap_or("");
+                        println!(
+                            "    [{}] {} {}",
+                            &t.id[..6.min(t.id.len())],
+                            t.title,
+                            if note.is_empty() {
+                                String::new()
+                            } else {
+                                format!("— {note}")
+                            }
+                        );
+                    }
+                }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::RoleClaim { role, summary, ttl } => {
             match chat::role_claim(&role, summary.as_deref(), ttl, room) {
@@ -2776,7 +3076,10 @@ fn main() {
                         println!("  Context: {summary}");
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
@@ -2793,49 +3096,58 @@ fn main() {
                         println!("  Context: {summary}");
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::RoleRelease { role } => {
-            match chat::role_release(&role, room) {
-                Ok(()) => println!("  Released role '{}'.", role),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::RoleRelease { role } => match chat::role_release(&role, room) {
+            Ok(()) => println!("  Released role '{}'.", role),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::Roles => {
-            match chat::list_role_leases(room) {
-                Ok(leases) => {
-                    if leases.is_empty() {
-                        println!("  (no role leases)");
-                        return;
+        Commands::Roles => match chat::list_role_leases(room) {
+            Ok(leases) => {
+                if leases.is_empty() {
+                    println!("  (no role leases)");
+                    return;
+                }
+                let now_ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                for lease in leases {
+                    let holder = resolve_display_name(&lease.agent_id);
+                    let state = if lease.lease_expires > now_ts {
+                        "active"
+                    } else {
+                        "expired"
+                    };
+                    println!(
+                        "  {} — {} [{}] until {}",
+                        lease.role,
+                        holder,
+                        state,
+                        ts(lease.lease_expires)
+                    );
+                    if let Some(summary) = lease.context_summary {
+                        println!("    {summary}");
                     }
-                    let now_ts = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs();
-                    for lease in leases {
-                        let holder = resolve_display_name(&lease.agent_id);
-                        let state = if lease.lease_expires > now_ts { "active" } else { "expired" };
-                        println!(
-                            "  {} — {} [{}] until {}",
-                            lease.role,
-                            holder,
-                            state,
-                            ts(lease.lease_expires)
-                        );
-                        if let Some(summary) = lease.context_summary {
-                            println!("    {summary}");
-                        }
-                        if !lease.last_task_ids.is_empty() {
-                            println!("    tasks: {}", lease.last_task_ids.join(", "));
-                        }
+                    if !lease.last_task_ids.is_empty() {
+                        println!("    tasks: {}", lease.last_task_ids.join(", "));
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Receipts { agent_id } => {
             match chat::list_work_receipts(agent_id.as_deref(), room) {
@@ -2856,7 +3168,10 @@ fn main() {
                             item.receipt.status
                         );
                         println!("    by: {name}");
-                        println!("    hash: {}", &item.receipt.task_hash[..12.min(item.receipt.task_hash.len())]);
+                        println!(
+                            "    hash: {}",
+                            &item.receipt.task_hash[..12.min(item.receipt.task_hash.len())]
+                        );
                         if !item.receipt.witness_ids.is_empty() {
                             println!("    witnesses: {}", item.receipt.witness_ids.join(", "));
                         }
@@ -2865,7 +3180,10 @@ fn main() {
                         }
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
@@ -2883,79 +3201,83 @@ fn main() {
             }
         }
 
-        Commands::Whois { agent_id } => {
-            match chat::whois(&agent_id, room) {
-                Ok(Some(p)) => {
-                    println!("  Agent:   {}", p.agent_id);
-                    if let Some(name) = &p.name {
-                        println!("  Name:    {name}");
-                    }
-                    if let Some(role) = &p.role {
-                        println!("  Role:    {role}");
-                    }
-                    let ago = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() - p.updated_at;
-                    println!("  Updated: {}s ago", ago);
+        Commands::Whois { agent_id } => match chat::whois(&agent_id, room) {
+            Ok(Some(p)) => {
+                println!("  Agent:   {}", p.agent_id);
+                if let Some(name) = &p.name {
+                    println!("  Name:    {name}");
                 }
-                Ok(None) => {
-                    println!("  No profile found for '{agent_id}'.");
+                if let Some(role) = &p.role {
+                    println!("  Role:    {role}");
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+                let ago = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs()
+                    - p.updated_at;
+                println!("  Updated: {}s ago", ago);
             }
-        }
+            Ok(None) => {
+                println!("  No profile found for '{agent_id}'.");
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Timeline { since } => {
-            match chat::timeline(&since, room) {
-                Ok(events) => {
-                    if events.is_empty() {
-                        println!("  (no activity in last {since})");
-                        return;
-                    }
-                    println!("  Timeline (last {since}, {} events):\n", events.len());
-                    for evt in &events {
-                        let time = ts(evt["ts"].as_u64().unwrap_or(0));
-                        let from = evt["from"].as_str().unwrap_or("?");
-                        let etype = evt["event_type"].as_str().unwrap_or("?");
-                        let icon = match etype {
-                            "join" => "+",
-                            "file" => "F",
-                            "profile" => "P",
-                            "work_receipt" => "W",
-                            "reaction" => "R",
-                            "topic" => "T",
-                            "admin" => "A",
-                            "kick" => "X",
-                            "scheduled" => "S",
-                            _ => " ",
-                        };
-                        let text = evt["text"].as_str().unwrap_or("");
-                        let short = &text[..60.min(text.len())];
-                        let name = resolve_display_name(from);
-                        println!("  {time} [{icon}] {name}: {short}");
-                    }
+        Commands::Timeline { since } => match chat::timeline(&since, room) {
+            Ok(events) => {
+                if events.is_empty() {
+                    println!("  (no activity in last {since})");
+                    return;
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                println!("  Timeline (last {since}, {} events):\n", events.len());
+                for evt in &events {
+                    let time = ts(evt["ts"].as_u64().unwrap_or(0));
+                    let from = evt["from"].as_str().unwrap_or("?");
+                    let etype = evt["event_type"].as_str().unwrap_or("?");
+                    let icon = match etype {
+                        "join" => "+",
+                        "file" => "F",
+                        "profile" => "P",
+                        "work_receipt" => "W",
+                        "reaction" => "R",
+                        "topic" => "T",
+                        "admin" => "A",
+                        "kick" => "X",
+                        "scheduled" => "S",
+                        _ => " ",
+                    };
+                    let text = evt["text"].as_str().unwrap_or("");
+                    let short = &text[..60.min(text.len())];
+                    let name = resolve_display_name(from);
+                    println!("  {time} [{icon}] {name}: {short}");
+                }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Digest { since, out } => {
-            match chat::digest(&since, room) {
-                Ok(report) => {
-                    if let Some(path) = out {
-                        std::fs::write(&path, &report).unwrap_or_else(|e| {
-                            eprintln!("  Error: {e}"); process::exit(1);
-                        });
-                        println!("  Digest written to: {path}");
-                    } else {
-                        println!("{report}");
-                    }
+        Commands::Digest { since, out } => match chat::digest(&since, room) {
+            Ok(report) => {
+                if let Some(path) = out {
+                    std::fs::write(&path, &report).unwrap_or_else(|e| {
+                        eprintln!("  Error: {e}");
+                        process::exit(1);
+                    });
+                    println!("  Digest written to: {path}");
+                } else {
+                    println!("{report}");
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Alias { agent_id, name } => {
             if let Some(n) = name {
@@ -2983,35 +3305,38 @@ fn main() {
             }
         }
 
-        Commands::WebhookAdd { url } => {
-            match chat::add_webhook(&url, room) {
-                Ok(id) => println!("  Webhook [{id}] added: {url}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::WebhookAdd { url } => match chat::add_webhook(&url, room) {
+            Ok(id) => println!("  Webhook [{id}] added: {url}"),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::WebhookList => {
-            match chat::list_webhooks(room) {
-                Ok(hooks) => {
-                    if hooks.is_empty() {
-                        println!("  (no webhooks)");
-                        return;
-                    }
-                    for h in &hooks {
-                        println!("  [{}] {}", h.id, h.url);
-                    }
+        Commands::WebhookList => match chat::list_webhooks(room) {
+            Ok(hooks) => {
+                if hooks.is_empty() {
+                    println!("  (no webhooks)");
+                    return;
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                for h in &hooks {
+                    println!("  [{}] {}", h.id, h.url);
+                }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::WebhookRemove { id } => {
-            match chat::remove_webhook(&id, room) {
-                Ok(true) => println!("  Webhook [{id}] removed."),
-                Ok(false) => println!("  Webhook [{id}] not found."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::WebhookRemove { id } => match chat::remove_webhook(&id, room) {
+            Ok(true) => println!("  Webhook [{id}] removed."),
+            Ok(false) => println!("  Webhook [{id}] not found."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
         Commands::Mentions { agent, since } => {
             match chat::mentions(agent.as_deref(), &since, room) {
@@ -3025,28 +3350,32 @@ fn main() {
                         print_msg(m);
                     }
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                Err(e) => {
+                    eprintln!("  Error: {e}");
+                    process::exit(1);
+                }
             }
         }
 
-        Commands::Links { since } => {
-            match chat::links(&since, room) {
-                Ok(links) => {
-                    if links.is_empty() {
-                        println!("  (no URLs shared in last {since})");
-                        return;
-                    }
-                    println!("  {} URL(s) shared in last {since}:\n", links.len());
-                    for l in &links {
-                        let url = l["url"].as_str().unwrap_or("?");
-                        let from = l["from"].as_str().unwrap_or("?");
-                        let time = ts(l["ts"].as_u64().unwrap_or(0));
-                        println!("  {time} [{from}] {url}");
-                    }
+        Commands::Links { since } => match chat::links(&since, room) {
+            Ok(links) => {
+                if links.is_empty() {
+                    println!("  (no URLs shared in last {since})");
+                    return;
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+                println!("  {} URL(s) shared in last {since}:\n", links.len());
+                for l in &links {
+                    let url = l["url"].as_str().unwrap_or("?");
+                    let from = l["from"].as_str().unwrap_or("?");
+                    let time = ts(l["ts"].as_u64().unwrap_or(0));
+                    println!("  {time} [{from}] {url}");
+                }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Encrypt { text, file } => {
             let data = if let Some(path) = file {
@@ -3062,43 +3391,6 @@ fn main() {
             };
             match chat::encrypt_data(&data, room) {
                 Ok(b64) => println!("{b64}"),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Decrypt { ciphertext, out } => {
-            match chat::decrypt_data(&ciphertext, room) {
-                Ok(data) => {
-                    if let Some(path) = out {
-                        std::fs::write(&path, &data).unwrap_or_else(|e| {
-                            eprintln!("  Error writing {path}: {e}");
-                            process::exit(1);
-                        });
-                        println!("  Decrypted to: {path}");
-                    } else {
-                        print!("{}", String::from_utf8_lossy(&data));
-                    }
-                }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Changelog { since } => {
-            match chat::changelog(&since, room) {
-                Ok(entries) => {
-                    if entries.is_empty() {
-                        println!("  (no changelog entries in last {since})");
-                        return;
-                    }
-                    println!("  Changelog (last {since}, {} entries):\n", entries.len());
-                    for e in &entries {
-                        let time = ts(e["ts"].as_u64().unwrap_or(0));
-                        let from = e["from"].as_str().unwrap_or("?");
-                        let text = e["text"].as_str().unwrap_or("");
-                        let short = &text[..80.min(text.len())];
-                        println!("  {time} [{from}] {short}");
-                    }
-                }
                 Err(e) => {
                     eprintln!("  Error: {e}");
                     process::exit(1);
@@ -3106,30 +3398,73 @@ fn main() {
             }
         }
 
-        Commands::Test => {
-            match chat::healthcheck(room) {
-                Ok(checks) => {
-                    println!("  Agora Health Check\n");
-                    let mut all_ok = true;
-                    for (name, ok, detail) in &checks {
-                        let icon = if *ok { "\x1b[92m\u{2713}\x1b[0m" } else { "\x1b[91m\u{2717}\x1b[0m" };
-                        println!("  {icon} {name:<20} {detail}");
-                        if !ok { all_ok = false; }
-                    }
-                    println!();
-                    if all_ok {
-                        println!("  \x1b[92mAll checks passed.\x1b[0m");
-                    } else {
-                        println!("  \x1b[91mSome checks failed.\x1b[0m");
+        Commands::Decrypt { ciphertext, out } => match chat::decrypt_data(&ciphertext, room) {
+            Ok(data) => {
+                if let Some(path) = out {
+                    std::fs::write(&path, &data).unwrap_or_else(|e| {
+                        eprintln!("  Error writing {path}: {e}");
                         process::exit(1);
+                    });
+                    println!("  Decrypted to: {path}");
+                } else {
+                    print!("{}", String::from_utf8_lossy(&data));
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Changelog { since } => match chat::changelog(&since, room) {
+            Ok(entries) => {
+                if entries.is_empty() {
+                    println!("  (no changelog entries in last {since})");
+                    return;
+                }
+                println!("  Changelog (last {since}, {} entries):\n", entries.len());
+                for e in &entries {
+                    let time = ts(e["ts"].as_u64().unwrap_or(0));
+                    let from = e["from"].as_str().unwrap_or("?");
+                    let text = e["text"].as_str().unwrap_or("");
+                    let short = &text[..80.min(text.len())];
+                    println!("  {time} [{from}] {short}");
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Test => match chat::healthcheck(room) {
+            Ok(checks) => {
+                println!("  Agora Health Check\n");
+                let mut all_ok = true;
+                for (name, ok, detail) in &checks {
+                    let icon = if *ok {
+                        "\x1b[92m\u{2713}\x1b[0m"
+                    } else {
+                        "\x1b[91m\u{2717}\x1b[0m"
+                    };
+                    println!("  {icon} {name:<20} {detail}");
+                    if !ok {
+                        all_ok = false;
                     }
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
+                println!();
+                if all_ok {
+                    println!("  \x1b[92mAll checks passed.\x1b[0m");
+                } else {
+                    println!("  \x1b[91mSome checks failed.\x1b[0m");
                     process::exit(1);
                 }
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
         Commands::Schedule { delay, message } => {
             let text = message.join(" ");
@@ -3138,7 +3473,9 @@ fn main() {
                 process::exit(1);
             }
             let now_ts = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
             let delay_secs = if let Some(m) = delay.strip_suffix('m') {
                 m.parse::<u64>().unwrap_or(5) * 60
             } else if let Some(h) = delay.strip_suffix('h') {
@@ -3156,41 +3493,6 @@ fn main() {
                         .unwrap_or_default();
                     println!("  Scheduled [{id}] for delivery at {dt} (in {delay}).");
                 }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Scheduled => {
-            match chat::list_scheduled(room) {
-                Ok(items) => {
-                    if items.is_empty() {
-                        println!("  (no scheduled messages)");
-                        return;
-                    }
-                    for item in &items {
-                        let id = item["id"].as_str().unwrap_or("?");
-                        let text = item["text"].as_str().unwrap_or("");
-                        let at = item["deliver_at"].as_u64().unwrap_or(0);
-                        let dt = chrono::DateTime::from_timestamp(at as i64, 0)
-                            .map(|d| d.format("%H:%M:%S").to_string())
-                            .unwrap_or_default();
-                        let short = &text[..40.min(text.len())];
-                        println!("  [{id}] at {dt}: {short}");
-                    }
-                }
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
-            }
-        }
-
-        Commands::Compact { keep_hours } => {
-            match chat::compact(keep_hours, room) {
-                Ok((archived, kept)) => {
-                    if archived == 0 {
-                        println!("  Nothing to compact ({kept} messages, all within {keep_hours}h).");
-                    } else {
-                        println!("  Compacted: {archived} messages archived, {kept} kept (last {keep_hours}h).");
-                    }
-                }
                 Err(e) => {
                     eprintln!("  Error: {e}");
                     process::exit(1);
@@ -3198,7 +3500,49 @@ fn main() {
             }
         }
 
-        Commands::Grep { query, regex: use_regex } => {
+        Commands::Scheduled => match chat::list_scheduled(room) {
+            Ok(items) => {
+                if items.is_empty() {
+                    println!("  (no scheduled messages)");
+                    return;
+                }
+                for item in &items {
+                    let id = item["id"].as_str().unwrap_or("?");
+                    let text = item["text"].as_str().unwrap_or("");
+                    let at = item["deliver_at"].as_u64().unwrap_or(0);
+                    let dt = chrono::DateTime::from_timestamp(at as i64, 0)
+                        .map(|d| d.format("%H:%M:%S").to_string())
+                        .unwrap_or_default();
+                    let short = &text[..40.min(text.len())];
+                    println!("  [{id}] at {dt}: {short}");
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Compact { keep_hours } => match chat::compact(keep_hours, room) {
+            Ok((archived, kept)) => {
+                if archived == 0 {
+                    println!("  Nothing to compact ({kept} messages, all within {keep_hours}h).");
+                } else {
+                    println!(
+                        "  Compacted: {archived} messages archived, {kept} kept (last {keep_hours}h)."
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
+
+        Commands::Grep {
+            query,
+            regex: use_regex,
+        } => {
             let q = query.join(" ");
             if q.is_empty() {
                 eprintln!("Usage: agora grep <query> [-e]");
@@ -3210,7 +3554,10 @@ fn main() {
                         println!("  No matches for '{q}' across any room.");
                         return;
                     }
-                    println!("  {} match(es) for '{q}' across all rooms:\n", results.len());
+                    println!(
+                        "  {} match(es) for '{q}' across all rooms:\n",
+                        results.len()
+                    );
                     let mut last_room = String::new();
                     for (room_label, msg) in &results {
                         if *room_label != last_room {
@@ -3252,79 +3599,75 @@ fn main() {
             }
         }
 
-        Commands::Stats => {
-            match chat::stats(room) {
-                Ok(s) => {
-                    let room_name = s["room"].as_str().unwrap_or("?");
-                    println!("  ╔═══ Stats: {} ═══╗\n", room_name);
-                    println!("  Messages:   {}", s["total_messages"]);
-                    println!("  Agents:     {}", s["total_agents"]);
-                    println!("  Characters: {}", s["total_characters"]);
-                    println!("  Files:      {}", s["total_files"]);
-                    println!("  Reactions:  {}", s["total_reactions"]);
-                    println!("  Receipts:   {}", s["total_receipts"]);
-                    println!("  Pins:       {}", s["total_pins"]);
-                    println!("  Profiles:   {}", s["total_profiles"]);
+        Commands::Stats => match chat::stats(room) {
+            Ok(s) => {
+                let room_name = s["room"].as_str().unwrap_or("?");
+                println!("  ╔═══ Stats: {} ═══╗\n", room_name);
+                println!("  Messages:   {}", s["total_messages"]);
+                println!("  Agents:     {}", s["total_agents"]);
+                println!("  Characters: {}", s["total_characters"]);
+                println!("  Files:      {}", s["total_files"]);
+                println!("  Reactions:  {}", s["total_reactions"]);
+                println!("  Receipts:   {}", s["total_receipts"]);
+                println!("  Pins:       {}", s["total_pins"]);
+                println!("  Profiles:   {}", s["total_profiles"]);
 
-                    if let Some(peak) = s["peak_hour"].as_object() {
-                        let pts = peak["ts"].as_u64().unwrap_or(0);
-                        println!("\n  Peak hour:  {} ({} msgs)", ts(pts), peak["messages"]);
+                if let Some(peak) = s["peak_hour"].as_object() {
+                    let pts = peak["ts"].as_u64().unwrap_or(0);
+                    println!("\n  Peak hour:  {} ({} msgs)", ts(pts), peak["messages"]);
+                }
+
+                println!("\n  Top agents:");
+                if let Some(agents) = s["agents"].as_array() {
+                    for a in agents.iter().take(10) {
+                        let id = a["id"].as_str().unwrap_or("?");
+                        let count = a["messages"].as_u64().unwrap_or(0);
+                        let bar = "█".repeat((count as usize).min(30));
+                        let name = resolve_display_name(id);
+                        println!("    {:<24} {:>4} {}", name, count, bar);
                     }
-
-                    println!("\n  Top agents:");
-                    if let Some(agents) = s["agents"].as_array() {
-                        for a in agents.iter().take(10) {
-                            let id = a["id"].as_str().unwrap_or("?");
-                            let count = a["messages"].as_u64().unwrap_or(0);
-                            let bar = "█".repeat((count as usize).min(30));
-                            let name = resolve_display_name(id);
-                            println!("    {:<24} {:>4} {}", name, count, bar);
-                        }
-                    }
-                    println!("\n  ╚{}╝", "═".repeat(30));
                 }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+                println!("\n  ╚{}╝", "═".repeat(30));
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::Mute { agent_id } => {
-            match chat::mute(&agent_id, room) {
-                Ok(()) => println!("  Muted {agent_id}. Their messages will be hidden."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::Mute { agent_id } => match chat::mute(&agent_id, room) {
+            Ok(()) => println!("  Muted {agent_id}. Their messages will be hidden."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::Unmute { agent_id } => {
-            match chat::unmute(&agent_id, room) {
-                Ok(()) => println!("  Unmuted {agent_id}."),
-                Err(e) => { eprintln!("  Error: {e}"); process::exit(1); }
+        Commands::Unmute { agent_id } => match chat::unmute(&agent_id, room) {
+            Ok(()) => println!("  Unmuted {agent_id}."),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
-        Commands::Export { since, out } => {
-            match chat::export(&since, out.as_deref(), room) {
-                Ok((path, count)) => {
-                    println!("  Exported {count} messages to: {path}");
-                }
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::Export { since, out } => match chat::export(&since, out.as_deref(), room) {
+            Ok((path, count)) => {
+                println!("  Exported {count} messages to: {path}");
             }
-        }
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
+            }
+        },
 
-        Commands::React { message_id, emoji } => {
-            match chat::react(&message_id, &emoji, room) {
-                Ok(()) => println!("  Reacted {emoji} to [{message_id}]"),
-                Err(e) => {
-                    eprintln!("  Error: {e}");
-                    process::exit(1);
-                }
+        Commands::React { message_id, emoji } => match chat::react(&message_id, &emoji, room) {
+            Ok(()) => println!("  Reacted {emoji} to [{message_id}]"),
+            Err(e) => {
+                eprintln!("  Error: {e}");
+                process::exit(1);
             }
-        }
+        },
 
         Commands::Serve { port } => {
             serve::start(port);
@@ -3364,11 +3707,18 @@ fn main() {
             println!("    Create or accept a private room for real work.\n");
 
             // 5. Set profile
-            let _ = chat::set_profile(Some(&display_name), Some(&format!("working on {project_name}")), Some("plaza"));
+            let _ = chat::set_profile(
+                Some(&display_name),
+                Some(&format!("working on {project_name}")),
+                Some("plaza"),
+            );
             println!("  \x1b[92m✓\x1b[0m Profile set\n");
 
             // 6. Announce
-            let announce = format!("New agent joined! {} — working on {}. Say hello!", display_name, project_name);
+            let announce = format!(
+                "New agent joined! {} — working on {}. Say hello!",
+                display_name, project_name
+            );
             let _ = chat::send(&announce, None, Some("plaza"));
             println!("  \x1b[92m✓\x1b[0m Announced in plaza\n");
 
@@ -3411,7 +3761,14 @@ fn main() {
             if display_id != key_id {
                 println!("  Key ID:     {key_id}");
             }
-            println!("  Identity:   {}", if persistent { "persistent (seed-derived)" } else { "ephemeral (session key)" });
+            println!(
+                "  Identity:   {}",
+                if persistent {
+                    "persistent (seed-derived)"
+                } else {
+                    "ephemeral (session key)"
+                }
+            );
             // Show public key if available
             let id_file = store::agora_dir().join("identity.json");
             if let Ok(data) = std::fs::read_to_string(&id_file) {
@@ -3429,11 +3786,11 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        default_display_name, dm_room_label, parse_invite_token, targeted_invite_token, InviteTokenAuth,
-        InviteTokenPayload,
+        InviteTokenAuth, InviteTokenPayload, default_display_name, dm_room_label,
+        parse_invite_token, targeted_invite_token,
     };
-    use base64::Engine;
     use crate::store::{self, RoomEntry};
+    use base64::Engine;
 
     fn temp_home() -> std::path::PathBuf {
         std::env::temp_dir().join(format!(
@@ -3574,8 +3931,10 @@ mod tests {
         let bytes = super::BASE64.decode(raw).unwrap();
         let mut signed: super::SignedInviteToken = serde_json::from_slice(&bytes).unwrap();
         signed.payload.label = "tampered".to_string();
-        let tampered =
-            format!("agr_{}", super::BASE64.encode(serde_json::to_vec(&signed).unwrap()));
+        let tampered = format!(
+            "agr_{}",
+            super::BASE64.encode(serde_json::to_vec(&signed).unwrap())
+        );
 
         let err = parse_invite_token(&tampered).unwrap_err();
         assert_eq!(err, "Invalid invite token signature.");
@@ -3606,7 +3965,8 @@ mod tests {
         }
 
         let agent_id = store::get_agent_id();
-        let (credits, trust_ledger) = crate::chat::credit_balance_check(None, None).unwrap_or((0, 0));
+        let (credits, trust_ledger) =
+            crate::chat::credit_balance_check(None, None).unwrap_or((0, 0));
         let (trust_score, receipt_count, rooms_active, vouches) =
             crate::chat::compute_agent_trust_score(&agent_id);
         let receipts = crate::chat::read_status(None).unwrap_or_default();
@@ -3625,9 +3985,18 @@ mod tests {
         // Verify all required fields are present
         assert!(out["agent_id"].is_string(), "agent_id must be a string");
         assert_eq!(out["agent_id"].as_str().unwrap(), "test-agent-status");
-        assert!(out["trust_score"].is_number(), "trust_score must be a number");
-        assert!(out["credit_balance"].is_number(), "credit_balance must be a number");
-        assert!(out["recent_receipts"].is_array(), "recent_receipts must be an array");
+        assert!(
+            out["trust_score"].is_number(),
+            "trust_score must be a number"
+        );
+        assert!(
+            out["credit_balance"].is_number(),
+            "credit_balance must be a number"
+        );
+        assert!(
+            out["recent_receipts"].is_array(),
+            "recent_receipts must be an array"
+        );
 
         // Verify it serializes to valid JSON
         let serialized = serde_json::to_string_pretty(&out).unwrap();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -15,7 +15,7 @@
 //! }
 //! ```
 
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::{self, BufRead, Write};
 
 use crate::{chat, store};
@@ -277,9 +277,7 @@ fn handle_tools_list() -> Result<Value, String> {
 }
 
 fn handle_tools_call(req: &Value) -> Result<Value, String> {
-    let tool_name = req["params"]["name"]
-        .as_str()
-        .ok_or("Missing tool name")?;
+    let tool_name = req["params"]["name"].as_str().ok_or("Missing tool name")?;
     let args = &req["params"]["arguments"];
 
     let result = match tool_name {
@@ -341,7 +339,8 @@ fn tool_read(args: &Value) -> Result<String, String> {
             .unwrap_or_default();
         let from = msg["from"].as_str().unwrap_or("?");
         let text = msg["text"].as_str().unwrap_or("");
-        let id = &msg["id"].as_str().unwrap_or("?")[..6.min(msg["id"].as_str().unwrap_or("?").len())];
+        let id =
+            &msg["id"].as_str().unwrap_or("?")[..6.min(msg["id"].as_str().unwrap_or("?").len())];
         out.push_str(&format!("[{dt}] [{id}] {from}: {text}\n"));
     }
     Ok(out)
@@ -357,7 +356,8 @@ fn tool_check(args: &Value) -> Result<String, String> {
     for msg in &msgs {
         let from = msg["from"].as_str().unwrap_or("?");
         let text = msg["text"].as_str().unwrap_or("");
-        let id = &msg["id"].as_str().unwrap_or("?")[..6.min(msg["id"].as_str().unwrap_or("?").len())];
+        let id =
+            &msg["id"].as_str().unwrap_or("?")[..6.min(msg["id"].as_str().unwrap_or("?").len())];
         out.push_str(&format!("[{id}] {from}: {text}\n"));
     }
     Ok(out)
@@ -420,21 +420,44 @@ fn tool_who(args: &Value) -> Result<String, String> {
     let online_only = args["online_only"].as_bool().unwrap_or(false);
     let members = chat::who(room, online_only)?;
     if members.is_empty() {
-        return Ok(if online_only { "No one online.".to_string() } else { "No members tracked.".to_string() });
+        return Ok(if online_only {
+            "No one online.".to_string()
+        } else {
+            "No members tracked.".to_string()
+        });
     }
     let me = store::get_agent_id();
     let now_ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
     let mut out = format!("{:<12} {:<8} {:<8} Last seen\n", "Agent", "Role", "Status");
     for m in &members {
         let role = format!("{:?}", m.role);
         let marker = if m.agent_id == me { " (you)" } else { "" };
-        let status = if m.last_seen > 0 && now_ts - m.last_seen < 300 { "online" } else if m.last_seen > 0 { "offline" } else { "unknown" };
+        let status = if m.last_seen > 0 && now_ts - m.last_seen < 300 {
+            "online"
+        } else if m.last_seen > 0 {
+            "offline"
+        } else {
+            "unknown"
+        };
         let seen = if m.last_seen > 0 {
             let ago = now_ts - m.last_seen;
-            if ago < 60 { format!("{ago}s ago") } else if ago < 3600 { format!("{}m ago", ago / 60) } else { format!("{}h ago", ago / 3600) }
-        } else { "never".to_string() };
-        out.push_str(&format!("{:<12} {:<8} {:<8} {seen}{marker}\n", m.agent_id, role, status));
+            if ago < 60 {
+                format!("{ago}s ago")
+            } else if ago < 3600 {
+                format!("{}m ago", ago / 60)
+            } else {
+                format!("{}h ago", ago / 3600)
+            }
+        } else {
+            "never".to_string()
+        };
+        out.push_str(&format!(
+            "{:<12} {:<8} {:<8} {seen}{marker}\n",
+            m.agent_id, role, status
+        ));
     }
     Ok(out)
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -19,7 +19,9 @@ pub struct SandboxSession {
 fn load_token(name: &str) -> Option<String> {
     // Env var first
     if let Ok(val) = std::env::var(name) {
-        if !val.is_empty() { return Some(val); }
+        if !val.is_empty() {
+            return Some(val);
+        }
     }
     // Fall back to tokens file
     let path = crate::store::agora_dir().join("sandbox-tokens.json");
@@ -33,9 +35,15 @@ fn load_token(name: &str) -> Option<String> {
     None
 }
 
-fn e2b_token() -> Option<String> { load_token("E2B_TOKEN") }
-fn daytona_token() -> Option<String> { load_token("DAYTONA_TOKEN") }
-fn sprites_token() -> Option<String> { load_token("SPRITES_TOKEN") }
+fn e2b_token() -> Option<String> {
+    load_token("E2B_TOKEN")
+}
+fn daytona_token() -> Option<String> {
+    load_token("DAYTONA_TOKEN")
+}
+fn sprites_token() -> Option<String> {
+    load_token("SPRITES_TOKEN")
+}
 
 fn client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
@@ -58,7 +66,10 @@ pub fn create(agent_id: &str) -> Result<SandboxSession, String> {
     if let Some(token) = sprites_token() {
         return create_sprites(agent_id, &token);
     }
-    Err("No sandbox provider configured. Set E2B_TOKEN, DAYTONA_TOKEN, or SPRITES_TOKEN.".to_string())
+    Err(
+        "No sandbox provider configured. Set E2B_TOKEN, DAYTONA_TOKEN, or SPRITES_TOKEN."
+            .to_string(),
+    )
 }
 
 /// Execute a command in a sandbox.
@@ -84,9 +95,15 @@ pub fn destroy(session_id: &str, provider: &str) -> Result<(), String> {
 /// List available providers.
 pub fn providers() -> Vec<String> {
     let mut p = Vec::new();
-    if e2b_token().is_some() { p.push("e2b".to_string()); }
-    if daytona_token().is_some() { p.push("daytona".to_string()); }
-    if sprites_token().is_some() { p.push("sprites".to_string()); }
+    if e2b_token().is_some() {
+        p.push("e2b".to_string());
+    }
+    if daytona_token().is_some() {
+        p.push("daytona".to_string());
+    }
+    if sprites_token().is_some() {
+        p.push("sprites".to_string());
+    }
     p
 }
 
@@ -104,7 +121,8 @@ fn create_e2b(agent_id: &str, token: &str) -> Result<SandboxSession, String> {
         .map_err(|e| format!("E2B create failed: {e}"))?;
 
     let body: serde_json::Value = resp.json().map_err(|e| format!("E2B parse failed: {e}"))?;
-    let sandbox_id = body["sandboxID"].as_str()
+    let sandbox_id = body["sandboxID"]
+        .as_str()
         .ok_or("E2B: no sandboxID in response")?
         .to_string();
 
@@ -112,7 +130,10 @@ fn create_e2b(agent_id: &str, token: &str) -> Result<SandboxSession, String> {
         id: sandbox_id,
         provider: "e2b".to_string(),
         agent_id: agent_id.to_string(),
-        created_at: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+        created_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
         status: "running".to_string(),
     })
 }
@@ -120,7 +141,9 @@ fn create_e2b(agent_id: &str, token: &str) -> Result<SandboxSession, String> {
 fn exec_e2b(session_id: &str, command: &str) -> Result<String, String> {
     let token = e2b_token().ok_or("E2B_TOKEN not set")?;
     let resp = client()
-        .post(&format!("https://api.e2b.dev/sandboxes/{session_id}/execute"))
+        .post(&format!(
+            "https://api.e2b.dev/sandboxes/{session_id}/execute"
+        ))
         .header("X-E2B-API-Key", &token)
         .json(&serde_json::json!({"command": command}))
         .send()
@@ -153,12 +176,19 @@ fn create_daytona(agent_id: &str, token: &str) -> Result<SandboxSession, String>
         .send()
         .map_err(|e| format!("Daytona create failed: {e}"))?;
 
-    let body: serde_json::Value = resp.json().map_err(|e| format!("Daytona parse failed: {e}"))?;
+    let body: serde_json::Value = resp
+        .json()
+        .map_err(|e| format!("Daytona parse failed: {e}"))?;
     let id = body["id"].as_str().unwrap_or("unknown").to_string();
 
     Ok(SandboxSession {
-        id, provider: "daytona".to_string(), agent_id: agent_id.to_string(),
-        created_at: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+        id,
+        provider: "daytona".to_string(),
+        agent_id: agent_id.to_string(),
+        created_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
         status: "running".to_string(),
     })
 }
@@ -166,7 +196,9 @@ fn create_daytona(agent_id: &str, token: &str) -> Result<SandboxSession, String>
 fn exec_daytona(session_id: &str, command: &str) -> Result<String, String> {
     let token = daytona_token().ok_or("DAYTONA_TOKEN not set")?;
     let resp = client()
-        .post(&format!("https://proxy.app-eu.daytona.io/toolbox/{session_id}/process/execute"))
+        .post(&format!(
+            "https://proxy.app-eu.daytona.io/toolbox/{session_id}/process/execute"
+        ))
         .bearer_auth(&token)
         .json(&serde_json::json!({"command": command}))
         .send()
@@ -175,7 +207,9 @@ fn exec_daytona(session_id: &str, command: &str) -> Result<String, String> {
     let body: serde_json::Value = resp.json().map_err(|e| format!("Daytona parse: {e}"))?;
     let output = body["result"].as_str().unwrap_or("");
     let exit_code = body["exitCode"].as_i64().unwrap_or(-1);
-    if exit_code != 0 { return Err(format!("Command failed (exit {}): {}", exit_code, output)); }
+    if exit_code != 0 {
+        return Err(format!("Command failed (exit {}): {}", exit_code, output));
+    }
     Ok(output.to_string())
 }
 
@@ -202,12 +236,19 @@ fn create_sprites(agent_id: &str, token: &str) -> Result<SandboxSession, String>
         .send()
         .map_err(|e| format!("Sprites create failed: {e}"))?;
 
-    let body: serde_json::Value = resp.json().map_err(|e| format!("Sprites parse failed: {e}"))?;
+    let body: serde_json::Value = resp
+        .json()
+        .map_err(|e| format!("Sprites parse failed: {e}"))?;
     let id = body["id"].as_str().unwrap_or("unknown").to_string();
 
     Ok(SandboxSession {
-        id, provider: "sprites".to_string(), agent_id: agent_id.to_string(),
-        created_at: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+        id,
+        provider: "sprites".to_string(),
+        agent_id: agent_id.to_string(),
+        created_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
         status: "running".to_string(),
     })
 }
@@ -215,7 +256,9 @@ fn create_sprites(agent_id: &str, token: &str) -> Result<SandboxSession, String>
 fn exec_sprites(session_id: &str, command: &str) -> Result<String, String> {
     let token = sprites_token().ok_or("SPRITES_TOKEN not set")?;
     let resp = client()
-        .post(&format!("https://api.sprites.dev/v1/machines/{session_id}/exec"))
+        .post(&format!(
+            "https://api.sprites.dev/v1/machines/{session_id}/exec"
+        ))
         .bearer_auth(&token)
         .json(&serde_json::json!({"command": command}))
         .send()
@@ -240,13 +283,15 @@ fn destroy_sprites(session_id: &str) -> Result<(), String> {
 /// Generate a time-limited sandbox access token for an agent.
 /// Token = base64(agent_id:expiry:HMAC(agent_id:expiry, server_secret))
 pub fn generate_agent_token(agent_id: &str, hours: u64) -> String {
-    let secret = std::env::var("AGORA_SANDBOX_SECRET")
-        .unwrap_or_else(|_| {
-            eprintln!("  [warn] AGORA_SANDBOX_SECRET not set — using insecure default");
-            "INSECURE-SET-AGORA_SANDBOX_SECRET".to_string()
-        });
+    let secret = std::env::var("AGORA_SANDBOX_SECRET").unwrap_or_else(|_| {
+        eprintln!("  [warn] AGORA_SANDBOX_SECRET not set — using insecure default");
+        "INSECURE-SET-AGORA_SANDBOX_SECRET".to_string()
+    });
     let expiry = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() + hours * 3600;
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + hours * 3600;
     // Use JSON for canonical framing (prevents HMAC concatenation forgery)
     let payload = serde_json::json!({"a": agent_id, "e": expiry}).to_string();
     let key = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, secret.as_bytes());
@@ -259,32 +304,39 @@ pub fn generate_agent_token(agent_id: &str, hours: u64) -> String {
 /// Verify an agent sandbox token. Returns (agent_id, expiry) if valid.
 pub fn verify_agent_token(token: &str) -> Result<(String, u64), String> {
     use base64::Engine;
-    let decoded = base64::engine::general_purpose::STANDARD.decode(token)
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(token)
         .map_err(|_| "Invalid token encoding")?;
     let token_str = String::from_utf8(decoded).map_err(|_| "Invalid token UTF-8")?;
     // Split on | (JSON payload | hex signature)
     let parts: Vec<&str> = token_str.splitn(2, '|').collect();
-    if parts.len() != 2 { return Err("Malformed token".to_string()); }
+    if parts.len() != 2 {
+        return Err("Malformed token".to_string());
+    }
 
     let payload = parts[0];
     let sig_hex = parts[1];
 
     // Parse JSON payload
-    let v: serde_json::Value = serde_json::from_str(payload).map_err(|_| "Invalid token payload")?;
+    let v: serde_json::Value =
+        serde_json::from_str(payload).map_err(|_| "Invalid token payload")?;
     let agent_id = v["a"].as_str().ok_or("Missing agent_id")?.to_string();
     let expiry = v["e"].as_u64().ok_or("Missing expiry")?;
 
     // Check expiry
     let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-    if now > expiry { return Err("Token expired".to_string()); }
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    if now > expiry {
+        return Err("Token expired".to_string());
+    }
 
     // Verify HMAC over canonical JSON
-    let secret = std::env::var("AGORA_SANDBOX_SECRET")
-        .unwrap_or_else(|_| {
-            eprintln!("  [warn] AGORA_SANDBOX_SECRET not set — using insecure default");
-            "INSECURE-SET-AGORA_SANDBOX_SECRET".to_string()
-        });
+    let secret = std::env::var("AGORA_SANDBOX_SECRET").unwrap_or_else(|_| {
+        eprintln!("  [warn] AGORA_SANDBOX_SECRET not set — using insecure default");
+        "INSECURE-SET-AGORA_SANDBOX_SECRET".to_string()
+    });
     let key = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, secret.as_bytes());
     let expected_sig = ring::hmac::sign(&key, payload.as_bytes());
     if hex::encode(expected_sig.as_ref()) != sig_hex {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -7,10 +7,10 @@
 //!   GET  /:room/events — SSE stream (new messages as HTML fragments)
 //!   POST /:room/send   — send a message, redirect back
 
+use crate::sandbox;
 use std::io::{Read as IoRead, Write as IoWrite};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
-use crate::sandbox;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::{chat, store};
@@ -136,9 +136,17 @@ pub fn render_message_html(
     let mid_short = &mid[..6.min(mid.len())];
     let is_reply = !m["reply_to"].as_str().unwrap_or("").is_empty();
     let class = if from.as_str() == me {
-        if is_reply { "msg me msg-reply" } else { "msg me" }
+        if is_reply {
+            "msg me msg-reply"
+        } else {
+            "msg me"
+        }
     } else {
-        if is_reply { "msg other msg-reply" } else { "msg other" }
+        if is_reply {
+            "msg other msg-reply"
+        } else {
+            "msg other"
+        }
     };
 
     let reply_to = m["reply_to"].as_str().unwrap_or("");
@@ -514,12 +522,15 @@ document.addEventListener('DOMContentLoaded',function(){{document.querySelectorA
         rows = rows,
         last_ts = last_ts,
         send_form = if readonly {
-            format!(r#"<div style="position:sticky;bottom:0;background:#0a0a0f;border-top:1px solid #1e1e2e;padding:20px 0;text-align:center">
+            format!(
+                r#"<div style="position:sticky;bottom:0;background:#0a0a0f;border-top:1px solid #1e1e2e;padding:20px 0;text-align:center">
               <p style="color:#8888a0;margin-bottom:12px">You are watching a live conversation between AI agents.</p>
               <a href="https://theagora.dev#install" style="background:linear-gradient(135deg,#6c5ce7,#00cec9);color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600">Install agora and join</a>
-            </div>"#)
+            </div>"#
+            )
         } else {
-            format!(r#"<div class="send-form">
+            format!(
+                r#"<div class="send-form">
   <div class="reply-banner" id="reply-banner">
     <span id="reply-label">↩ replying to …</span>
     <span class="cancel-reply" onclick="cancelReply()" title="Cancel reply">✕</span>
@@ -529,14 +540,16 @@ document.addEventListener('DOMContentLoaded',function(){{document.querySelectorA
     <input type="text" name="message" id="msg-input" placeholder="Type a message… (Enter to send)" autofocus>
     <button type="submit">Send</button>
   </form>
-</div>"#, label = html_escape(room_label))
+</div>"#,
+                label = html_escape(room_label)
+            )
         },
     )
 }
 
 fn render_thread_page(room_label: &str, message_id: &str) -> Result<String, String> {
-    let room = store::find_room(room_label)
-        .ok_or_else(|| format!("Room '{room_label}' not found."))?;
+    let room =
+        store::find_room(room_label).ok_or_else(|| format!("Room '{room_label}' not found."))?;
     let me = store::get_agent_id();
     let items = chat::thread(message_id, Some(room_label))?;
     if items.is_empty() {
@@ -548,8 +561,7 @@ fn render_thread_page(room_label: &str, message_id: &str) -> Result<String, Stri
         .and_then(|item| item.env["id"].as_str())
         .ok_or_else(|| "Thread root is missing an ID.".to_string())?;
     let root_id_js = serde_json::to_string(root_id).unwrap_or_else(|_| "\"\"".to_string());
-    let room_label_js =
-        serde_json::to_string(room_label).unwrap_or_else(|_| "\"\"".to_string());
+    let room_label_js = serde_json::to_string(room_label).unwrap_or_else(|_| "\"\"".to_string());
     let thread_count = items.len();
     let reply_count = thread_count.saturating_sub(1);
     let last_ts = items
@@ -752,11 +764,11 @@ fn render_leaderboard_page(rows: &[serde_json::Value]) -> String {
 
     let mut table_rows = String::new();
     for row in rows {
-        let rank    = row["rank"].as_u64().unwrap_or(0) as usize;
+        let rank = row["rank"].as_u64().unwrap_or(0) as usize;
         let display = row["display"].as_str().unwrap_or("?");
         let credits = row["credits"].as_i64().unwrap_or(0);
-        let trust   = row["trust"].as_i64().unwrap_or(0);
-        let color   = medal(rank);
+        let trust = row["trust"].as_i64().unwrap_or(0);
+        let color = medal(rank);
         table_rows.push_str(&format!(
             r#"<tr><td style="color:{color};font-weight:bold">#{rank}</td><td style="color:#e6edf3">{display}</td><td style="color:#58a6ff;text-align:right">{credits}</td><td style="color:#3fb950;text-align:right">{trust}</td></tr>"#,
             color = color, rank = rank,
@@ -769,7 +781,8 @@ fn render_leaderboard_page(rows: &[serde_json::Value]) -> String {
         table_rows = r#"<tr><td colspan="4" style="color:#484f58;text-align:center">No agents yet — solve seeds to appear here</td></tr>"#.to_string();
     }
 
-    format!(r#"<!DOCTYPE html>
+    format!(
+        r#"<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -837,10 +850,7 @@ fn parse_request(raw: &str) -> (&str, &str, &str) {
     let method = parts.next().unwrap_or("GET");
     let path = parts.next().unwrap_or("/");
 
-    let body = raw
-        .split_once("\r\n\r\n")
-        .map(|(_, b)| b)
-        .unwrap_or("");
+    let body = raw.split_once("\r\n\r\n").map(|(_, b)| b).unwrap_or("");
 
     (method, path, body)
 }
@@ -861,7 +871,10 @@ fn get_header<'a>(raw: &'a str, name: &str) -> Option<&'a str> {
 
 fn bearer_token(raw: &str) -> Option<&str> {
     get_header(raw, "Authorization")
-        .and_then(|h| h.strip_prefix("Bearer ").or_else(|| h.strip_prefix("bearer ")))
+        .and_then(|h| {
+            h.strip_prefix("Bearer ")
+                .or_else(|| h.strip_prefix("bearer "))
+        })
         .map(str::trim)
         .filter(|token| !token.is_empty())
 }
@@ -879,12 +892,7 @@ fn audit_now() -> u64 {
         .as_secs()
 }
 
-fn sandbox_audit_id(
-    agent_id: &str,
-    action: &str,
-    session_id: Option<&str>,
-    ts: u64,
-) -> String {
+fn sandbox_audit_id(agent_id: &str, action: &str, session_id: Option<&str>, ts: u64) -> String {
     use ring::digest;
     let input = format!(
         "agora-sandbox-audit-v1\n{agent_id}\n{action}\n{}\n{ts}",
@@ -1073,7 +1081,11 @@ fn handle_sse(mut stream: TcpStream, room_label: String, since_ts: u64) {
 
 fn handle_connection(stream: TcpStream) {
     let mut buf = vec![0u8; 8192];
-    let n = match stream.try_clone().ok().and_then(|mut s| s.read(&mut buf).ok()) {
+    let n = match stream
+        .try_clone()
+        .ok()
+        .and_then(|mut s| s.read(&mut buf).ok())
+    {
         Some(n) => n,
         None => return,
     };
@@ -1087,7 +1099,12 @@ fn handle_connection(stream: TcpStream) {
     match (method, segments.as_slice()) {
         // GET / — room index
         ("GET", [""]) | ("GET", []) => {
-            send_response(stream, "200 OK", "text/html; charset=utf-8", &render_index());
+            send_response(
+                stream,
+                "200 OK",
+                "text/html; charset=utf-8",
+                &render_index(),
+            );
         }
 
         // GET /:room/events — SSE stream
@@ -1098,19 +1115,21 @@ fn handle_connection(stream: TcpStream) {
         }
 
         // GET /:room/thread/:id — thread view
-        ("GET", [room_label, "thread", message_id]) => match render_thread_page(room_label, message_id) {
-            Ok(page) => send_response(stream, "200 OK", "text/html; charset=utf-8", &page),
-            Err(err) => send_response(
-                stream,
-                "404 Not Found",
-                "text/html; charset=utf-8",
-                &format!(
-                    r#"<!DOCTYPE html><html><body style="font-family:monospace;background:#0d1117;color:#c9d1d9;padding:20px"><h1>Thread not found</h1><p>{}</p><p><a href="/{}" style="color:#58a6ff">Back to room</a></p></body></html>"#,
-                    html_escape(&err),
-                    html_escape(room_label),
+        ("GET", [room_label, "thread", message_id]) => {
+            match render_thread_page(room_label, message_id) {
+                Ok(page) => send_response(stream, "200 OK", "text/html; charset=utf-8", &page),
+                Err(err) => send_response(
+                    stream,
+                    "404 Not Found",
+                    "text/html; charset=utf-8",
+                    &format!(
+                        r#"<!DOCTYPE html><html><body style="font-family:monospace;background:#0d1117;color:#c9d1d9;padding:20px"><h1>Thread not found</h1><p>{}</p><p><a href="/{}" style="color:#58a6ff">Back to room</a></p></body></html>"#,
+                        html_escape(&err),
+                        html_escape(room_label),
+                    ),
                 ),
-            ),
-        },
+            }
+        }
 
         // GET /leaderboard — HTML leaderboard page (must precede /:room catch-all)
         ("GET", ["leaderboard"]) => {
@@ -1148,10 +1167,9 @@ fn handle_connection(stream: TcpStream) {
 
         // POST /:room/react — add emoji reaction (called by web UI via fetch)
         ("POST", [room_label, "react"]) => {
-            if let (Some(msg_id), Some(emoji)) = (
-                form_field(body, "message_id"),
-                form_field(body, "emoji"),
-            ) {
+            if let (Some(msg_id), Some(emoji)) =
+                (form_field(body, "message_id"), form_field(body, "emoji"))
+            {
                 let msg_id = msg_id.trim().to_string();
                 let emoji = emoji.trim().to_string();
                 if !msg_id.is_empty() && !emoji.is_empty() {
@@ -1169,7 +1187,11 @@ fn handle_connection(stream: TcpStream) {
             let verified_agent_id = match verify_bearer_agent_token(&raw) {
                 Ok(agent_id) => agent_id,
                 Err(e) => {
-                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        401,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                     return;
                 }
             };
@@ -1204,17 +1226,26 @@ fn handle_connection(stream: TcpStream) {
             let token = form_field(body, "token").unwrap_or_default();
             let (verified_agent_id, _expiry) = match sandbox::verify_agent_token(&token) {
                 Ok(v) => v,
-                Err(e) => { send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e)); return; }
+                Err(e) => {
+                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e));
+                    return;
+                }
             };
             // Atomic credit gate — check-and-debit in a single locked operation to
             // prevent TOCTOU races where two concurrent requests both pass the balance
             // check and then both deduct, driving the account negative.
             let room_id = form_field(body, "room_id").unwrap_or_else(|| "plaza".to_string());
             if let Err(e) = store::atomic_credit_debit(
-                &room_id, &verified_agent_id,
-                SANDBOX_OPEN_COST_CREDITS, "sandbox:open",
+                &room_id,
+                &verified_agent_id,
+                SANDBOX_OPEN_COST_CREDITS,
+                "sandbox:open",
             ) {
-                send_json(stream, 402, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                send_json(
+                    stream,
+                    402,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                );
                 return;
             }
             // Bug fix: always use the verified agent_id from the token
@@ -1241,8 +1272,10 @@ fn handle_connection(stream: TcpStream) {
                     // Sandbox creation failed — refund the pre-charged credits so the
                     // agent is not penalised for a provider-side failure.
                     store::credit_add(
-                        &room_id, &verified_agent_id,
-                        SANDBOX_OPEN_COST_CREDITS, "sandbox:open:refund",
+                        &room_id,
+                        &verified_agent_id,
+                        SANDBOX_OPEN_COST_CREDITS,
+                        "sandbox:open:refund",
                     );
                     append_sandbox_audit(
                         &verified_agent_id,
@@ -1254,7 +1287,11 @@ fn handle_connection(stream: TcpStream) {
                         "error",
                         Some(&e),
                     );
-                    send_json(stream, 500, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        500,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                 }
             }
         }
@@ -1264,7 +1301,10 @@ fn handle_connection(stream: TcpStream) {
             let token = form_field(body, "token").unwrap_or_default();
             let (verified_agent_id, _expiry) = match sandbox::verify_agent_token(&token) {
                 Ok(v) => v,
-                Err(e) => { send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e)); return; }
+                Err(e) => {
+                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e));
+                    return;
+                }
             };
             let _ = verified_agent_id; // TODO: verify session belongs to this agent
             let session_id = form_field(body, "session_id").unwrap_or_default();
@@ -1272,7 +1312,11 @@ fn handle_connection(stream: TcpStream) {
             let provider = form_field(body, "provider").unwrap_or_else(|| "daytona".to_string());
             let room_id = form_field(body, "room_id");
             if session_id.is_empty() || command.is_empty() {
-                send_json(stream, 400, r#"{"error":"session_id and command required"}"#);
+                send_json(
+                    stream,
+                    400,
+                    r#"{"error":"session_id and command required"}"#,
+                );
                 return;
             }
             match sandbox::exec(&session_id, &command, &provider) {
@@ -1287,7 +1331,11 @@ fn handle_connection(stream: TcpStream) {
                         "success",
                         None,
                     );
-                    send_json(stream, 200, &serde_json::json!({"output": output}).to_string())
+                    send_json(
+                        stream,
+                        200,
+                        &serde_json::json!({"output": output}).to_string(),
+                    )
                 }
                 Err(e) => {
                     append_sandbox_audit(
@@ -1300,7 +1348,11 @@ fn handle_connection(stream: TcpStream) {
                         "error",
                         Some(&e),
                     );
-                    send_json(stream, 500, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")))
+                    send_json(
+                        stream,
+                        500,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    )
                 }
             }
         }
@@ -1310,7 +1362,10 @@ fn handle_connection(stream: TcpStream) {
             let token = form_field(body, "token").unwrap_or_default();
             let (verified_agent_id, _expiry) = match sandbox::verify_agent_token(&token) {
                 Ok(v) => v,
-                Err(e) => { send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e)); return; }
+                Err(e) => {
+                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e));
+                    return;
+                }
             };
             let _ = verified_agent_id; // TODO: verify session belongs to this agent
             let session_id = form_field(body, "session_id").unwrap_or_default();
@@ -1345,7 +1400,11 @@ fn handle_connection(stream: TcpStream) {
                         "error",
                         Some(&e),
                     );
-                    send_json(stream, 500, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")))
+                    send_json(
+                        stream,
+                        500,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    )
                 }
             }
         }
@@ -1363,7 +1422,11 @@ fn handle_connection(stream: TcpStream) {
             let credits = match parsed["credits"].as_i64() {
                 Some(n) if n > 0 => n,
                 _ => {
-                    send_json(stream, 400, r#"{"error":"credits must be a positive integer"}"#);
+                    send_json(
+                        stream,
+                        400,
+                        r#"{"error":"credits must be a positive integer"}"#,
+                    );
                     return;
                 }
             };
@@ -1373,7 +1436,11 @@ fn handle_connection(stream: TcpStream) {
                     let resp = serde_json::json!({"checkout_url": checkout_url});
                     send_json(stream, 200, &resp.to_string());
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1384,7 +1451,11 @@ fn handle_connection(stream: TcpStream) {
             // Verify Stripe-Signature header using HMAC-SHA256 (replay window: 5 minutes)
             let webhook_secret = std::env::var("STRIPE_WEBHOOK_SECRET").unwrap_or_default();
             if webhook_secret.is_empty() {
-                send_json(stream, 500, r#"{"error":"STRIPE_WEBHOOK_SECRET not configured"}"#);
+                send_json(
+                    stream,
+                    500,
+                    r#"{"error":"STRIPE_WEBHOOK_SECRET not configured"}"#,
+                );
                 return;
             }
 
@@ -1409,7 +1480,11 @@ fn handle_connection(stream: TcpStream) {
                 let room_id = session["metadata"]["room_id"].as_str().unwrap_or("");
 
                 if stripe_session_id.is_empty() || room_id.is_empty() {
-                    send_json(stream, 400, r#"{"error":"missing session_id or room_id in metadata"}"#);
+                    send_json(
+                        stream,
+                        400,
+                        r#"{"error":"missing session_id or room_id in metadata"}"#,
+                    );
                     return;
                 }
 
@@ -1418,7 +1493,11 @@ fn handle_connection(stream: TcpStream) {
                     Err(e) => {
                         eprintln!("  [webhook] payment_complete_deposit error: {e}");
                         // Return 200 to Stripe even on idempotency errors to avoid retries
-                        send_json(stream, 200, r#"{"received":true,"note":"already processed or not found"}"#);
+                        send_json(
+                            stream,
+                            200,
+                            r#"{"received":true,"note":"already processed or not found"}"#,
+                        );
                     }
                 }
             } else {
@@ -1430,11 +1509,21 @@ fn handle_connection(stream: TcpStream) {
         // GET /api/health — structured health check for Railway + ops monitoring
         // Always returns 200 so Railway healthcheck passes; status field indicates readiness
         ("GET", ["api", "health"]) => {
-            let e2b     = std::env::var("E2B_TOKEN").map(|v| !v.is_empty()).unwrap_or(false);
-            let daytona = std::env::var("DAYTONA_TOKEN").map(|v| !v.is_empty()).unwrap_or(false);
-            let sprites = std::env::var("SPRITES_TOKEN").map(|v| !v.is_empty()).unwrap_or(false);
-            let stripe_key     = std::env::var("STRIPE_SECRET_KEY").map(|v| !v.is_empty()).unwrap_or(false);
-            let stripe_webhook = std::env::var("STRIPE_WEBHOOK_SECRET").map(|v| !v.is_empty()).unwrap_or(false);
+            let e2b = std::env::var("E2B_TOKEN")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
+            let daytona = std::env::var("DAYTONA_TOKEN")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
+            let sprites = std::env::var("SPRITES_TOKEN")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
+            let stripe_key = std::env::var("STRIPE_SECRET_KEY")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
+            let stripe_webhook = std::env::var("STRIPE_WEBHOOK_SECRET")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
             let relay_url = std::env::var("AGORA_RELAY_URL")
                 .unwrap_or_else(|_| "https://ntfy.theagora.dev".to_string());
             let sandbox_ok = e2b || daytona || sprites;
@@ -1473,15 +1562,20 @@ fn handle_connection(stream: TcpStream) {
         // Query params: room=<label|id>  (optional)
         ("GET", ["api", "v1", "bounties"]) => {
             let qs = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-            let room_param = qs.split('&').find_map(|kv| {
-                kv.strip_prefix("room=").map(|v| url_decode(v))
-            });
+            let room_param = qs
+                .split('&')
+                .find_map(|kv| kv.strip_prefix("room=").map(|v| url_decode(v)));
             match chat::bounty_list(room_param.as_deref()) {
                 Ok(bounties) => {
-                    let body = serde_json::to_string(&bounties).unwrap_or_else(|_| "[]".to_string());
+                    let body =
+                        serde_json::to_string(&bounties).unwrap_or_else(|_| "[]".to_string());
                     send_json(stream, 200, &body);
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1492,7 +1586,11 @@ fn handle_connection(stream: TcpStream) {
             let agent_id = match verify_bearer_agent_token(&raw) {
                 Ok(id) => id,
                 Err(e) => {
-                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        401,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                     return;
                 }
             };
@@ -1535,7 +1633,11 @@ fn handle_connection(stream: TcpStream) {
                     });
                     send_json(stream, 201, &resp.to_string());
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1546,7 +1648,11 @@ fn handle_connection(stream: TcpStream) {
             let _agent_id = match verify_bearer_agent_token(&raw) {
                 Ok(id) => id,
                 Err(e) => {
-                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        401,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                     return;
                 }
             };
@@ -1576,7 +1682,11 @@ fn handle_connection(stream: TcpStream) {
                     });
                     send_json(stream, 200, &resp.to_string());
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1587,7 +1697,11 @@ fn handle_connection(stream: TcpStream) {
             let _caller = match verify_bearer_agent_token(&raw) {
                 Ok(id) => id,
                 Err(e) => {
-                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        401,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                     return;
                 }
             };
@@ -1618,7 +1732,11 @@ fn handle_connection(stream: TcpStream) {
                     });
                     send_json(stream, 200, &resp.to_string());
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1629,18 +1747,27 @@ fn handle_connection(stream: TcpStream) {
             let _caller = match verify_bearer_agent_token(&raw) {
                 Ok(id) => id,
                 Err(e) => {
-                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        401,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                     return;
                 }
             };
-            let parsed: serde_json::Value = serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
+            let parsed: serde_json::Value =
+                serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
             let room_label = parsed["room"].as_str().map(|s| s.to_string());
             match chat::bounty_expire_check(room_label.as_deref()) {
                 Ok(expired_ids) => {
                     let resp = serde_json::json!({"expired": expired_ids});
                     send_json(stream, 200, &resp.to_string());
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1648,21 +1775,27 @@ fn handle_connection(stream: TcpStream) {
         // Query params: room=<label|id>  status=open|claimed|done  (both optional)
         ("GET", ["api", "v1", "tasks"]) => {
             let qs = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-            let room_param = qs.split('&').find_map(|kv| {
-                kv.strip_prefix("room=").map(|v| url_decode(v))
-            });
-            let status_filter = qs.split('&').find_map(|kv| {
-                kv.strip_prefix("status=").map(|v| url_decode(v))
-            });
+            let room_param = qs
+                .split('&')
+                .find_map(|kv| kv.strip_prefix("room=").map(|v| url_decode(v)));
+            let status_filter = qs
+                .split('&')
+                .find_map(|kv| kv.strip_prefix("status=").map(|v| url_decode(v)));
             match chat::task_list(room_param.as_deref()) {
                 Ok(tasks) => {
-                    let filtered: Vec<_> = tasks.iter().filter(|t| {
-                        status_filter.as_deref().map_or(true, |s| t.status == s)
-                    }).collect();
-                    let body = serde_json::to_string(&filtered).unwrap_or_else(|_| "[]".to_string());
+                    let filtered: Vec<_> = tasks
+                        .iter()
+                        .filter(|t| status_filter.as_deref().map_or(true, |s| t.status == s))
+                        .collect();
+                    let body =
+                        serde_json::to_string(&filtered).unwrap_or_else(|_| "[]".to_string());
                     send_json(stream, 200, &body);
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1673,7 +1806,11 @@ fn handle_connection(stream: TcpStream) {
             let agent_id = match verify_bearer_agent_token(&raw) {
                 Ok(agent_id) => agent_id,
                 Err(e) => {
-                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        401,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                     return;
                 }
             };
@@ -1697,7 +1834,11 @@ fn handle_connection(stream: TcpStream) {
                     let resp = serde_json::json!({"id": id, "title": title, "status": "open", "created_by": agent_id});
                     send_json(stream, 201, &resp.to_string());
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1705,16 +1846,20 @@ fn handle_connection(stream: TcpStream) {
         // Query param: room=<label|id>  (optional)
         ("GET", ["api", "v1", "tasks", task_id]) => {
             let qs = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-            let room_param = qs.split('&').find_map(|kv| {
-                kv.strip_prefix("room=").map(|v| url_decode(v))
-            });
+            let room_param = qs
+                .split('&')
+                .find_map(|kv| kv.strip_prefix("room=").map(|v| url_decode(v)));
             let tid = (*task_id).to_string();
             match chat::task_get(&tid, room_param.as_deref()) {
                 Ok(task) => {
                     let body = serde_json::to_string(&task).unwrap_or_else(|_| "{}".to_string());
                     send_json(stream, 200, &body);
                 }
-                Err(e) => send_json(stream, 404, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    404,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1725,7 +1870,11 @@ fn handle_connection(stream: TcpStream) {
             let agent_id = match verify_bearer_agent_token(&raw) {
                 Ok(agent_id) => agent_id,
                 Err(e) => {
-                    send_json(stream, 401, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")));
+                    send_json(
+                        stream,
+                        401,
+                        &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                    );
                     return;
                 }
             };
@@ -1739,7 +1888,11 @@ fn handle_connection(stream: TcpStream) {
             let action = match parsed["action"].as_str().filter(|s| !s.is_empty()) {
                 Some(a) => a.to_string(),
                 None => {
-                    send_json(stream, 400, r#"{"error":"action is required (claim|done|checkpoint|reject)"}"#);
+                    send_json(
+                        stream,
+                        400,
+                        r#"{"error":"action is required (claim|done|checkpoint|reject)"}"#,
+                    );
                     return;
                 }
             };
@@ -1748,26 +1901,37 @@ fn handle_connection(stream: TcpStream) {
             let tid = (*task_id).to_string();
             let result = match action.as_str() {
                 "claim" => chat::task_claim_as(&agent_id, &tid, room_label.as_deref()),
-                "done" => chat::task_done_as(&agent_id, &tid, notes.as_deref(), room_label.as_deref()),
-                "checkpoint" => {
-                    chat::task_checkpoint_as(&agent_id, &tid, notes.as_deref(), room_label.as_deref())
+                "done" => {
+                    chat::task_done_as(&agent_id, &tid, notes.as_deref(), room_label.as_deref())
                 }
+                "checkpoint" => chat::task_checkpoint_as(
+                    &agent_id,
+                    &tid,
+                    notes.as_deref(),
+                    room_label.as_deref(),
+                ),
                 "reject" => {
                     chat::task_reject_as(&agent_id, &tid, notes.as_deref(), room_label.as_deref())
                 }
-                _ => Err(format!("Unknown action '{}'; use claim|done|checkpoint|reject", action)),
+                _ => Err(format!(
+                    "Unknown action '{}'; use claim|done|checkpoint|reject",
+                    action
+                )),
             };
             match result {
-                Ok(_) => {
-                    match chat::task_get(&tid, room_label.as_deref()) {
-                        Ok(task) => {
-                            let body = serde_json::to_string(&task).unwrap_or_else(|_| "{}".to_string());
-                            send_json(stream, 200, &body);
-                        }
-                        Err(_) => send_json(stream, 200, r#"{"status":"ok"}"#),
+                Ok(_) => match chat::task_get(&tid, room_label.as_deref()) {
+                    Ok(task) => {
+                        let body =
+                            serde_json::to_string(&task).unwrap_or_else(|_| "{}".to_string());
+                        send_json(stream, 200, &body);
                     }
-                }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                    Err(_) => send_json(stream, 200, r#"{"status":"ok"}"#),
+                },
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1778,7 +1942,11 @@ fn handle_connection(stream: TcpStream) {
                 qs.split('&').find_map(|kv| {
                     let mut parts = kv.splitn(2, '=');
                     let k = parts.next()?;
-                    if k == "room" { parts.next().map(|v| v.to_string()) } else { None }
+                    if k == "room" {
+                        parts.next().map(|v| v.to_string())
+                    } else {
+                        None
+                    }
                 })
             });
             match chat::payment_history(room.as_deref()) {
@@ -1786,7 +1954,11 @@ fn handle_connection(stream: TcpStream) {
                     let resp = serde_json::to_string(&records).unwrap_or_else(|_| "[]".to_string());
                     send_json(stream, 200, &resp);
                 }
-                Err(e) => send_json(stream, 400, &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'"))),
+                Err(e) => send_json(
+                    stream,
+                    400,
+                    &format!(r#"{{"error":"{}"}}"#, e.replace('"', "'")),
+                ),
             }
         }
 
@@ -1903,7 +2075,10 @@ mod tests {
 
     #[test]
     fn test_parse_since_ts_present() {
-        assert_eq!(parse_since_ts("/collab/events?since=1234567890"), 1_234_567_890);
+        assert_eq!(
+            parse_since_ts("/collab/events?since=1234567890"),
+            1_234_567_890
+        );
     }
 
     #[test]
@@ -2027,21 +2202,27 @@ mod tests {
             .unwrap()
             .as_secs();
         let room = store::add_room("ag-thread-test", "secret", "collab", store::Role::Admin);
-        store::save_message(&room.room_id, &serde_json::json!({
-            "id": "root1234",
-            "from": "alice",
-            "ts": now,
-            "text": "root",
-            "v": "4.0",
-        }));
-        store::save_message(&room.room_id, &serde_json::json!({
-            "id": "reply5678",
-            "from": "bob",
-            "ts": now + 1,
-            "text": "reply",
-            "reply_to": "root1234",
-            "v": "4.0",
-        }));
+        store::save_message(
+            &room.room_id,
+            &serde_json::json!({
+                "id": "root1234",
+                "from": "alice",
+                "ts": now,
+                "text": "root",
+                "v": "4.0",
+            }),
+        );
+        store::save_message(
+            &room.room_id,
+            &serde_json::json!({
+                "id": "reply5678",
+                "from": "bob",
+                "ts": now + 1,
+                "text": "reply",
+                "reply_to": "root1234",
+                "v": "4.0",
+            }),
+        );
 
         let html = render_thread_page("collab", "root1234").unwrap();
         assert!(html.contains("message(s) in this thread"));
@@ -2070,16 +2251,19 @@ mod tests {
         }
 
         let room = store::add_room("ag-readonly-test", "secret", "plaza", store::Role::Admin);
-        store::save_message(&room.room_id, &serde_json::json!({
-            "id": "root1234",
-            "from": "alice",
-            "ts": std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-            "text": "hello",
-            "v": "4.0",
-        }));
+        store::save_message(
+            &room.room_id,
+            &serde_json::json!({
+                "id": "root1234",
+                "from": "alice",
+                "ts": std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+                "text": "hello",
+                "v": "4.0",
+            }),
+        );
 
         let html = render_room_page("plaza");
         assert!(html.contains("Install agora and join"));
@@ -2136,7 +2320,8 @@ mod tests {
             std::env::set_var("AGORA_SANDBOX_SECRET", "serve-test-secret");
         }
         let token = crate::sandbox::generate_agent_token("api-agent", 1);
-        let raw = format!("POST /api/v1/tasks HTTP/1.1\r\nAuthorization: Bearer {token}\r\n\r\n{{}}");
+        let raw =
+            format!("POST /api/v1/tasks HTTP/1.1\r\nAuthorization: Bearer {token}\r\n\r\n{{}}");
         let verified = verify_bearer_agent_token(&raw).expect("token should verify");
         assert_eq!(verified, "api-agent");
     }
@@ -2388,13 +2573,27 @@ mod tests {
         // Without STRIPE_SECRET_KEY or sandbox tokens, status should be "degraded"
         // and all sub-fields should be false.
         // We just test the JSON shape via the logic directly (no env vars set in CI).
-        let e2b     = std::env::var("E2B_TOKEN").map(|v| !v.is_empty()).unwrap_or(false);
-        let daytona = std::env::var("DAYTONA_TOKEN").map(|v| !v.is_empty()).unwrap_or(false);
-        let sprites = std::env::var("SPRITES_TOKEN").map(|v| !v.is_empty()).unwrap_or(false);
-        let stripe_key     = std::env::var("STRIPE_SECRET_KEY").map(|v| !v.is_empty()).unwrap_or(false);
-        let stripe_webhook = std::env::var("STRIPE_WEBHOOK_SECRET").map(|v| !v.is_empty()).unwrap_or(false);
+        let e2b = std::env::var("E2B_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let daytona = std::env::var("DAYTONA_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let sprites = std::env::var("SPRITES_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let stripe_key = std::env::var("STRIPE_SECRET_KEY")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
+        let stripe_webhook = std::env::var("STRIPE_WEBHOOK_SECRET")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
         let sandbox_ok = e2b || daytona || sprites;
-        let expected_status = if sandbox_ok && stripe_key { "ok" } else { "degraded" };
+        let expected_status = if sandbox_ok && stripe_key {
+            "ok"
+        } else {
+            "degraded"
+        };
         let body = serde_json::json!({
             "status": expected_status,
             "version": env!("CARGO_PKG_VERSION"),
@@ -2422,12 +2621,12 @@ mod tests {
         // Simulate the same query-string extraction used in GET /api/v1/tasks
         let path = "/api/v1/tasks?room=plaza&status=open";
         let qs = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-        let room_param = qs.split('&').find_map(|kv| {
-            kv.strip_prefix("room=").map(|v| url_decode(v))
-        });
-        let status_filter = qs.split('&').find_map(|kv| {
-            kv.strip_prefix("status=").map(|v| url_decode(v))
-        });
+        let room_param = qs
+            .split('&')
+            .find_map(|kv| kv.strip_prefix("room=").map(|v| url_decode(v)));
+        let status_filter = qs
+            .split('&')
+            .find_map(|kv| kv.strip_prefix("status=").map(|v| url_decode(v)));
         assert_eq!(room_param.as_deref(), Some("plaza"));
         assert_eq!(status_filter.as_deref(), Some("open"));
     }
@@ -2436,12 +2635,12 @@ mod tests {
     fn tasks_api_query_param_optional() {
         let path = "/api/v1/tasks";
         let qs = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-        let room_param: Option<String> = qs.split('&').find_map(|kv| {
-            kv.strip_prefix("room=").map(|v| url_decode(v))
-        });
-        let status_filter: Option<String> = qs.split('&').find_map(|kv| {
-            kv.strip_prefix("status=").map(|v| url_decode(v))
-        });
+        let room_param: Option<String> = qs
+            .split('&')
+            .find_map(|kv| kv.strip_prefix("room=").map(|v| url_decode(v)));
+        let status_filter: Option<String> = qs
+            .split('&')
+            .find_map(|kv| kv.strip_prefix("status=").map(|v| url_decode(v)));
         assert!(room_param.is_none());
         assert!(status_filter.is_none());
     }
@@ -2558,7 +2757,9 @@ mod tests {
         assert_eq!(segments[3], "abc123");
         // Query is extracted separately
         let qs = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-        let room_param = qs.split('&').find_map(|kv| kv.strip_prefix("room=").map(|v| v.to_string()));
+        let room_param = qs
+            .split('&')
+            .find_map(|kv| kv.strip_prefix("room=").map(|v| v.to_string()));
         assert_eq!(room_param.as_deref(), Some("collab"));
     }
 
@@ -2581,7 +2782,9 @@ mod tests {
         let segments: Vec<&str> = path_only.trim_start_matches('/').split('/').collect();
         assert_eq!(segments.as_slice(), &["api", "v1", "bounties"]);
         let qs = path.split_once('?').map(|(_, q)| q).unwrap_or("");
-        let room_param = qs.split('&').find_map(|kv| kv.strip_prefix("room=").map(|v| v.to_string()));
+        let room_param = qs
+            .split('&')
+            .find_map(|kv| kv.strip_prefix("room=").map(|v| v.to_string()));
         assert_eq!(room_param.as_deref(), Some("plaza"));
     }
 
@@ -2658,7 +2861,12 @@ mod tests {
     fn bounties_api_submit_body_missing_branch() {
         let body = r#"{"room": "collab"}"#;
         let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
-        assert!(parsed["branch"].as_str().filter(|s| !s.is_empty()).is_none());
+        assert!(
+            parsed["branch"]
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .is_none()
+        );
     }
 
     #[test]
@@ -2673,14 +2881,20 @@ mod tests {
     fn bounties_api_verify_body_missing_agent_id() {
         let body = r#"{"room": "plaza"}"#;
         let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
-        assert!(parsed["agent_id"].as_str().filter(|s| !s.is_empty()).is_none());
+        assert!(
+            parsed["agent_id"]
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .is_none()
+        );
     }
 
     #[test]
     fn bounties_api_expire_body_optional_room() {
         // Empty body is valid — room defaults to active room
         let body = "{}";
-        let parsed: serde_json::Value = serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
+        let parsed: serde_json::Value =
+            serde_json::from_str(body).unwrap_or(serde_json::Value::Null);
         assert!(parsed["room"].as_str().is_none());
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -90,8 +90,11 @@ fn generate_identity() -> (String, Vec<u8>) {
     if let Ok(seed) = std::env::var("AGORA_IDENTITY_SEED") {
         let hk = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, b"agora-identity-v1");
         let derived = ring::hmac::sign(&hk, seed.as_bytes());
-        let seed_bytes: [u8; 32] = derived.as_ref()[..32].try_into().expect("HMAC-SHA256 is 32 bytes");
-        let pkcs8 = crypto::generate_signing_keypair_from_seed(&seed_bytes).expect("keygen from seed");
+        let seed_bytes: [u8; 32] = derived.as_ref()[..32]
+            .try_into()
+            .expect("HMAC-SHA256 is 32 bytes");
+        let pkcs8 =
+            crypto::generate_signing_keypair_from_seed(&seed_bytes).expect("keygen from seed");
         let pubkey = crypto::signing_public_key(&pkcs8).unwrap();
         let id = derive_key_id(&pubkey);
         return (id, pkcs8);
@@ -391,10 +394,7 @@ pub fn remove_room(label_or_id: &str) -> Option<RoomEntry> {
 // ── Message Persistence ─────────────────────────────────────────
 
 pub fn save_message(room_id: &str, envelope: &serde_json::Value) {
-    let dir = agora_dir()
-        .join("rooms")
-        .join(room_id)
-        .join("messages");
+    let dir = agora_dir().join("rooms").join(room_id).join("messages");
     ensure_dir(&dir);
     let ts = envelope["ts"].as_u64().unwrap_or_else(now);
     let mid = envelope["id"].as_str().unwrap_or("x");
@@ -406,7 +406,9 @@ pub fn save_message(room_id: &str, envelope: &serde_json::Value) {
 
 pub fn delete_message(room_id: &str, msg_id: &str) {
     let dir = agora_dir().join("rooms").join(room_id).join("messages");
-    if !dir.exists() { return; }
+    if !dir.exists() {
+        return;
+    }
     if let Ok(entries) = fs::read_dir(&dir) {
         for entry in entries.flatten() {
             let name = entry.file_name().to_string_lossy().to_string();
@@ -419,10 +421,7 @@ pub fn delete_message(room_id: &str, msg_id: &str) {
 }
 
 pub fn load_messages(room_id: &str, since_secs: u64) -> Vec<serde_json::Value> {
-    let dir = agora_dir()
-        .join("rooms")
-        .join(room_id)
-        .join("messages");
+    let dir = agora_dir().join("rooms").join(room_id).join("messages");
     if !dir.exists() {
         return vec![];
     }
@@ -501,7 +500,10 @@ pub struct AgentProfile {
 }
 
 pub fn load_profiles(room_id: &str) -> Vec<AgentProfile> {
-    let path = agora_dir().join("rooms").join(room_id).join("profiles.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("profiles.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -527,7 +529,9 @@ pub fn upsert_profile(room_id: &str, profile: &AgentProfile) {
 }
 
 pub fn get_profile(room_id: &str, agent_id: &str) -> Option<AgentProfile> {
-    load_profiles(room_id).into_iter().find(|p| p.agent_id == agent_id)
+    load_profiles(room_id)
+        .into_iter()
+        .find(|p| p.agent_id == agent_id)
 }
 
 // ── Agent Capability Cards ─────────────────────────────────────
@@ -614,7 +618,10 @@ pub fn unmute_agent(room_id: &str, agent_id: &str) {
 // receipts.json: { "msg_id": ["agent1", "agent2"], ... }
 
 pub fn load_receipts(room_id: &str) -> std::collections::HashMap<String, Vec<String>> {
-    let path = agora_dir().join("rooms").join(room_id).join("receipts.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("receipts.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -644,7 +651,10 @@ pub fn record_receipts(room_id: &str, msg_ids: &[String], reader: &str) {
 // reactions.json: { "msg_id": [["agent", "emoji"], ...] }
 
 pub fn load_reactions(room_id: &str) -> std::collections::HashMap<String, Vec<(String, String)>> {
-    let path = agora_dir().join("rooms").join(room_id).join("reactions.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("reactions.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -652,7 +662,10 @@ pub fn load_reactions(room_id: &str) -> std::collections::HashMap<String, Vec<(S
     }
 }
 
-pub fn save_reactions(room_id: &str, reactions: &std::collections::HashMap<String, Vec<(String, String)>>) {
+pub fn save_reactions(
+    room_id: &str,
+    reactions: &std::collections::HashMap<String, Vec<(String, String)>>,
+) {
     let dir = agora_dir().join("rooms").join(room_id);
     ensure_dir(&dir);
     let data = serde_json::to_string(reactions).unwrap();
@@ -711,8 +724,11 @@ pub struct CreditEntry {
 
 pub fn load_ledger(room_id: &str) -> Vec<CreditEntry> {
     let path = agora_dir().join("rooms").join(room_id).join("ledger.json");
-    if let Ok(data) = fs::read_to_string(&path) { serde_json::from_str(&data).unwrap_or_default() }
-    else { Vec::new() }
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
 }
 
 pub fn save_ledger(room_id: &str, ledger: &[CreditEntry]) {
@@ -729,23 +745,31 @@ fn ledger_lock() -> &'static Mutex<()> {
 }
 
 pub fn credit_balance(room_id: &str, agent_id: &str) -> i64 {
-    load_ledger(room_id).iter()
+    load_ledger(room_id)
+        .iter()
         .filter(|e| e.agent_id == agent_id && (e.ledger.is_empty() || e.ledger == "credit"))
-        .map(|e| e.amount).sum()
+        .map(|e| e.amount)
+        .sum()
 }
 
 pub fn trust_balance(room_id: &str, agent_id: &str) -> i64 {
-    load_ledger(room_id).iter()
+    load_ledger(room_id)
+        .iter()
         .filter(|e| e.agent_id == agent_id && e.ledger == "trust")
-        .map(|e| e.amount).sum()
+        .map(|e| e.amount)
+        .sum()
 }
 
 pub fn credit_add(room_id: &str, agent_id: &str, amount: i64, reason: &str) {
     let _guard = ledger_lock().lock().unwrap();
     let mut ledger = load_ledger(room_id);
     ledger.push(CreditEntry {
-        agent_id: agent_id.to_string(), amount, reason: reason.to_string(),
-        ts: now(), ledger: "credit".to_string(), verified_by: "admin".to_string(),
+        agent_id: agent_id.to_string(),
+        amount,
+        reason: reason.to_string(),
+        ts: now(),
+        ledger: "credit".to_string(),
+        verified_by: "admin".to_string(),
     });
     save_ledger(room_id, &ledger);
 }
@@ -753,8 +777,12 @@ pub fn credit_add(room_id: &str, agent_id: &str, amount: i64, reason: &str) {
 pub fn trust_add(room_id: &str, agent_id: &str, amount: i64, reason: &str, verified_by: &str) {
     let mut ledger = load_ledger(room_id);
     ledger.push(CreditEntry {
-        agent_id: agent_id.to_string(), amount, reason: reason.to_string(),
-        ts: now(), ledger: "trust".to_string(), verified_by: verified_by.to_string(),
+        agent_id: agent_id.to_string(),
+        amount,
+        reason: reason.to_string(),
+        ts: now(),
+        ledger: "trust".to_string(),
+        verified_by: verified_by.to_string(),
     });
     save_ledger(room_id, &ledger);
 }
@@ -813,14 +841,20 @@ pub struct Bet {
 
 pub fn load_bets(room_id: &str) -> Vec<Bet> {
     let path = agora_dir().join("rooms").join(room_id).join("bets.json");
-    if let Ok(data) = fs::read_to_string(&path) { serde_json::from_str(&data).unwrap_or_default() }
-    else { Vec::new() }
+    if let Ok(data) = fs::read_to_string(&path) {
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        Vec::new()
+    }
 }
 
 pub fn save_bets(room_id: &str, bets: &[Bet]) {
     let dir = agora_dir().join("rooms").join(room_id);
     ensure_dir(&dir);
-    let _ = fs::write(dir.join("bets.json"), serde_json::to_string_pretty(bets).unwrap());
+    let _ = fs::write(
+        dir.join("bets.json"),
+        serde_json::to_string_pretty(bets).unwrap(),
+    );
 }
 
 // ── Capability Cards ───────────────────────────────────────────
@@ -843,7 +877,9 @@ pub fn save_card(card: &CapabilityCard) {
 
 pub fn load_card() -> Option<CapabilityCard> {
     let path = agora_dir().join("card.json");
-    fs::read_to_string(&path).ok().and_then(|d| serde_json::from_str(&d).ok())
+    fs::read_to_string(&path)
+        .ok()
+        .and_then(|d| serde_json::from_str(&d).ok())
 }
 
 pub fn save_peer_card(room_id: &str, card: &CapabilityCard) {
@@ -855,7 +891,9 @@ pub fn save_peer_card(room_id: &str, card: &CapabilityCard) {
 
 pub fn load_peer_cards(room_id: &str) -> Vec<CapabilityCard> {
     let dir = agora_dir().join("rooms").join(room_id).join("cards");
-    if !dir.exists() { return Vec::new(); }
+    if !dir.exists() {
+        return Vec::new();
+    }
     let mut cards = Vec::new();
     if let Ok(entries) = fs::read_dir(&dir) {
         for entry in entries.flatten() {
@@ -1020,11 +1058,16 @@ pub fn load_payments() -> Vec<PaymentRecord> {
 pub fn save_payments(payments: &[PaymentRecord]) {
     let dir = agora_dir();
     ensure_dir(&dir);
-    let _ = fs::write(dir.join("payments.json"), serde_json::to_string_pretty(payments).unwrap());
+    let _ = fs::write(
+        dir.join("payments.json"),
+        serde_json::to_string_pretty(payments).unwrap(),
+    );
 }
 
 pub fn find_payment_by_stripe_id(stripe_id: &str) -> Option<PaymentRecord> {
-    load_payments().into_iter().find(|p| p.stripe_id.as_deref() == Some(stripe_id))
+    load_payments()
+        .into_iter()
+        .find(|p| p.stripe_id.as_deref() == Some(stripe_id))
 }
 
 pub fn find_payment_by_reference(reference: &str) -> Option<PaymentRecord> {
@@ -1077,7 +1120,10 @@ pub struct CalibrationSeed {
 }
 
 pub fn load_seeds(room_id: &str) -> Vec<CalibrationSeed> {
-    let path = agora_dir().join("rooms").join(room_id).join("calibration_seeds.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("calibration_seeds.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -1121,7 +1167,10 @@ fn default_receipt_status() -> String {
 }
 
 pub fn load_work_receipts(room_id: &str) -> Vec<WorkReceipt> {
-    let path = agora_dir().join("rooms").join(room_id).join("work_receipts.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("work_receipts.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -1176,7 +1225,10 @@ pub struct SandboxLease {
 }
 
 pub fn load_leases(room_id: &str) -> Vec<SandboxLease> {
-    let path = agora_dir().join("rooms").join(room_id).join("sandbox_leases.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("sandbox_leases.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -1198,7 +1250,10 @@ pub fn open_lease(room_id: &str, lease: SandboxLease) -> Result<(), String> {
         .iter()
         .any(|l| l.agent_id == lease.agent_id && l.status == LeaseStatus::Active)
     {
-        return Err(format!("Agent {} already has an active lease", lease.agent_id));
+        return Err(format!(
+            "Agent {} already has an active lease",
+            lease.agent_id
+        ));
     }
     leases.push(lease);
     save_leases(room_id, &leases);
@@ -1253,7 +1308,10 @@ pub struct RoleLease {
 }
 
 pub fn load_role_leases(room_id: &str) -> Vec<RoleLease> {
-    let path = agora_dir().join("rooms").join(room_id).join("role_leases.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("role_leases.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -1339,7 +1397,10 @@ pub struct Webhook {
 }
 
 pub fn load_webhooks(room_id: &str) -> Vec<Webhook> {
-    let path = agora_dir().join("rooms").join(room_id).join("webhooks.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("webhooks.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -1372,7 +1433,9 @@ pub fn remove_webhook(room_id: &str, webhook_id: &str) -> bool {
     let mut hooks = load_webhooks(room_id);
     let before = hooks.len();
     hooks.retain(|h| h.id != webhook_id);
-    if hooks.len() == before { return false; }
+    if hooks.len() == before {
+        return false;
+    }
     save_webhooks(room_id, &hooks);
     true
 }
@@ -1380,7 +1443,10 @@ pub fn remove_webhook(room_id: &str, webhook_id: &str) -> bool {
 // ── Scheduled Messages ─────────────────────────────────────────
 
 pub fn load_scheduled(room_id: &str) -> Vec<serde_json::Value> {
-    let path = agora_dir().join("rooms").join(room_id).join("scheduled.json");
+    let path = agora_dir()
+        .join("rooms")
+        .join(room_id)
+        .join("scheduled.json");
     if let Ok(data) = fs::read_to_string(&path) {
         serde_json::from_str(&data).unwrap_or_default()
     } else {
@@ -1465,7 +1531,9 @@ mod tests {
         fs::write(agora.join("rooms.json"), "{not-json").unwrap();
 
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         update_last_seen("missing-room", "agent-1");
 
@@ -1473,9 +1541,13 @@ mod tests {
         assert_eq!(persisted, "{not-json");
 
         if let Some(old) = old_home {
-            unsafe { env::set_var("HOME", old); }
+            unsafe {
+                env::set_var("HOME", old);
+            }
         } else {
-            unsafe { env::remove_var("HOME"); }
+            unsafe {
+                env::remove_var("HOME");
+            }
         }
         let _ = fs::remove_dir_all(&home);
     }
@@ -1489,7 +1561,9 @@ mod tests {
         fs::create_dir_all(&agora).unwrap();
 
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         let room = RoomEntry {
             room_id: "room-1".to_string(),
@@ -1507,9 +1581,13 @@ mod tests {
         assert_eq!(parsed[0].label, "plaza");
 
         if let Some(old) = old_home {
-            unsafe { env::set_var("HOME", old); }
+            unsafe {
+                env::set_var("HOME", old);
+            }
         } else {
-            unsafe { env::remove_var("HOME"); }
+            unsafe {
+                env::remove_var("HOME");
+            }
         }
         let _ = fs::remove_dir_all(&home);
     }
@@ -1523,7 +1601,9 @@ mod tests {
         fs::create_dir_all(&agora).unwrap();
 
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         let record = PaymentRecord {
             id: "pay-test-001".to_string(),
@@ -1561,9 +1641,13 @@ mod tests {
         assert!(found_by_reference.is_some());
 
         if let Some(old) = old_home {
-            unsafe { env::set_var("HOME", old); }
+            unsafe {
+                env::set_var("HOME", old);
+            }
         } else {
-            unsafe { env::remove_var("HOME"); }
+            unsafe {
+                env::remove_var("HOME");
+            }
         }
         let _ = fs::remove_dir_all(&home);
     }
@@ -1587,7 +1671,9 @@ mod tests {
         fs::create_dir_all(&agora).unwrap();
 
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         let record = SandboxAuditRecord {
             id: "audit-1".to_string(),
@@ -1613,9 +1699,13 @@ mod tests {
         assert_eq!(loaded[0].command_len, Some(12));
 
         if let Some(old) = old_home {
-            unsafe { env::set_var("HOME", old); }
+            unsafe {
+                env::set_var("HOME", old);
+            }
         } else {
-            unsafe { env::remove_var("HOME"); }
+            unsafe {
+                env::remove_var("HOME");
+            }
         }
         let _ = fs::remove_dir_all(&home);
     }
@@ -1628,7 +1718,9 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
         fs::create_dir_all(&agora).unwrap();
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         let lease = SandboxLease {
             id: "sandbox-1".to_string(),
@@ -1648,8 +1740,15 @@ mod tests {
         assert_eq!(leases[0].status, LeaseStatus::Closed);
         assert_eq!(leases[0].actual_cost, Some(42));
 
-        if let Some(old) = old_home { unsafe { env::set_var("HOME", old); } }
-        else { unsafe { env::remove_var("HOME"); } }
+        if let Some(old) = old_home {
+            unsafe {
+                env::set_var("HOME", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("HOME");
+            }
+        }
         let _ = fs::remove_dir_all(&home);
     }
 
@@ -1661,7 +1760,9 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
         fs::create_dir_all(&agora).unwrap();
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         let lease = SandboxLease {
             id: "sandbox-1".to_string(),
@@ -1674,11 +1775,21 @@ mod tests {
             closed_at: None,
         };
         open_lease("room-1", lease.clone()).unwrap();
-        let second = SandboxLease { id: "sandbox-2".to_string(), ..lease };
+        let second = SandboxLease {
+            id: "sandbox-2".to_string(),
+            ..lease
+        };
         assert!(open_lease("room-1", second).is_err());
 
-        if let Some(old) = old_home { unsafe { env::set_var("HOME", old); } }
-        else { unsafe { env::remove_var("HOME"); } }
+        if let Some(old) = old_home {
+            unsafe {
+                env::set_var("HOME", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("HOME");
+            }
+        }
         let _ = fs::remove_dir_all(&home);
     }
 
@@ -1690,7 +1801,9 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
         fs::create_dir_all(&agora).unwrap();
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         // A lease that started well beyond MAX_LEASE_SECS ago
         let stale_lease = SandboxLease {
@@ -1730,8 +1843,15 @@ mod tests {
         assert_eq!(stale.status, LeaseStatus::Closed);
         assert_eq!(fresh.status, LeaseStatus::Active);
 
-        if let Some(old) = old_home { unsafe { env::set_var("HOME", old); } }
-        else { unsafe { env::remove_var("HOME"); } }
+        if let Some(old) = old_home {
+            unsafe {
+                env::set_var("HOME", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("HOME");
+            }
+        }
         let _ = fs::remove_dir_all(&home);
     }
 
@@ -1742,15 +1862,24 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
         fs::create_dir_all(home.join(".agora")).unwrap();
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         credit_add("room-1", "agent-1", 50, "seed");
         let result = atomic_credit_debit("room-1", "agent-1", 10, "sandbox:open");
         assert_eq!(result, Ok(40));
         assert_eq!(credit_balance("room-1", "agent-1"), 40);
 
-        if let Some(old) = old_home { unsafe { env::set_var("HOME", old); } }
-        else { unsafe { env::remove_var("HOME"); } }
+        if let Some(old) = old_home {
+            unsafe {
+                env::set_var("HOME", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("HOME");
+            }
+        }
         let _ = fs::remove_dir_all(&home);
     }
 
@@ -1761,7 +1890,9 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
         fs::create_dir_all(home.join(".agora")).unwrap();
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         credit_add("room-1", "agent-1", 5, "seed");
         let result = atomic_credit_debit("room-1", "agent-1", 10, "sandbox:open");
@@ -1769,8 +1900,15 @@ mod tests {
         // Balance must be unchanged after a failed debit
         assert_eq!(credit_balance("room-1", "agent-1"), 5);
 
-        if let Some(old) = old_home { unsafe { env::set_var("HOME", old); } }
-        else { unsafe { env::remove_var("HOME"); } }
+        if let Some(old) = old_home {
+            unsafe {
+                env::set_var("HOME", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("HOME");
+            }
+        }
         let _ = fs::remove_dir_all(&home);
     }
 
@@ -1781,15 +1919,24 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
         fs::create_dir_all(home.join(".agora")).unwrap();
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         // No credits added — debit must fail
         let result = atomic_credit_debit("room-1", "agent-1", 1, "sandbox:open");
         assert!(result.is_err());
         assert_eq!(credit_balance("room-1", "agent-1"), 0);
 
-        if let Some(old) = old_home { unsafe { env::set_var("HOME", old); } }
-        else { unsafe { env::remove_var("HOME"); } }
+        if let Some(old) = old_home {
+            unsafe {
+                env::set_var("HOME", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("HOME");
+            }
+        }
         let _ = fs::remove_dir_all(&home);
     }
 
@@ -1800,7 +1947,9 @@ mod tests {
         let _ = fs::remove_dir_all(&home);
         fs::create_dir_all(home.join(".agora")).unwrap();
         let old_home = env::var("HOME").ok();
-        unsafe { env::set_var("HOME", &home); }
+        unsafe {
+            env::set_var("HOME", &home);
+        }
 
         credit_add("room-1", "agent-1", 10, "seed");
         let result = atomic_credit_debit("room-1", "agent-1", 10, "sandbox:open");
@@ -1809,8 +1958,15 @@ mod tests {
         let second = atomic_credit_debit("room-1", "agent-1", 1, "sandbox:open");
         assert!(second.is_err());
 
-        if let Some(old) = old_home { unsafe { env::set_var("HOME", old); } }
-        else { unsafe { env::remove_var("HOME"); } }
+        if let Some(old) = old_home {
+            unsafe {
+                env::set_var("HOME", old);
+            }
+        } else {
+            unsafe {
+                env::remove_var("HOME");
+            }
+        }
         let _ = fs::remove_dir_all(&home);
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -74,7 +74,10 @@ fn streaming_client() -> reqwest::blocking::Client {
 pub fn publish(topic: &str, payload: &str) -> bool {
     let base = relay_url();
     let url = format!("{base}/{topic}");
-    let ok = match apply_auth(client().post(&url)).body(payload.to_string()).send() {
+    let ok = match apply_auth(client().post(&url))
+        .body(payload.to_string())
+        .send()
+    {
         Ok(resp) => resp.status().is_success(),
         Err(e) => {
             eprintln!("  [warn] relay publish failed: {e}");
@@ -182,7 +185,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{mirror_url, relay_status_label, relay_token, relay_url, DEFAULT_RELAY};
+    use super::{DEFAULT_RELAY, mirror_url, relay_status_label, relay_token, relay_url};
     use crate::store;
 
     fn restore_env(name: &str, value: Option<String>) {
@@ -194,7 +197,9 @@ mod tests {
 
     #[test]
     fn relay_url_defaults_to_ntfy() {
-        let _guard = store::test_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = store::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("AGORA_RELAY_URL").ok();
         unsafe { std::env::remove_var("AGORA_RELAY_URL") };
 
@@ -205,7 +210,9 @@ mod tests {
 
     #[test]
     fn relay_url_uses_env_override() {
-        let _guard = store::test_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = store::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("AGORA_RELAY_URL").ok();
         unsafe { std::env::set_var("AGORA_RELAY_URL", "https://ntfy.theagora.dev") };
 
@@ -216,7 +223,9 @@ mod tests {
 
     #[test]
     fn mirror_url_is_optional() {
-        let _guard = store::test_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = store::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("AGORA_RELAY_MIRROR").ok();
         unsafe { std::env::remove_var("AGORA_RELAY_MIRROR") };
         // Auto-mirror to ntfy.sh when using theagora.dev relay
@@ -231,7 +240,9 @@ mod tests {
 
     #[test]
     fn relay_token_is_optional() {
-        let _guard = store::test_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = store::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("AGORA_RELAY_TOKEN").ok();
         unsafe { std::env::remove_var("AGORA_RELAY_TOKEN") };
         assert_eq!(relay_token(), None);
@@ -244,14 +255,13 @@ mod tests {
 
     #[test]
     fn relay_status_label_reflects_override() {
-        let _guard = store::test_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = store::test_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let prior = std::env::var("AGORA_RELAY_URL").ok();
         unsafe { std::env::set_var("AGORA_RELAY_URL", "https://ntfy.theagora.dev") };
 
-        assert_eq!(
-            relay_status_label(),
-            "Relay (https://ntfy.theagora.dev)"
-        );
+        assert_eq!(relay_status_label(), "Relay (https://ntfy.theagora.dev)");
 
         restore_env("AGORA_RELAY_URL", prior);
     }


### PR DESCRIPTION
## Summary

- Runs `cargo fmt` to fix formatting drift on main (previously 418 diffs across 8 files)
- Adds a `fmt` CI job that blocks unformatted PRs before build/test runs

## Test plan

- [x] `cargo fmt --check` passes
- [x] 155 tests pass
- [x] No logic changes — formatting only + CI gate addition

https://claude.ai/code/session_01CTKnetPke9GCb9Mj717WjP