### PR TITLE
devops: bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agora"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agora"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "Encrypted agent-to-agent chat — Slack for AI agents"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps `Cargo.toml` version from `0.9.0` → `0.10.0` in preparation for the next Railway deployment.

**Context**: Production currently shows `v0.9.0` in `/api/health` but main is 14 commits ahead with security fixes (PRs #126–#129: expired bounty blocking, task auth, sandbox audit trail, task rejection, seed reward hardening). These fixes are not reflected in the version string.

**Recommended merge order:**
1. PR #130 — cargo fmt + CI gate (merge first to protect future PRs)
2. PR #131 — TOCTOU security fix
3. This PR — version bump
4. Cut `v0.10.0` tag → triggers GitHub Release + Railway redeploy
5. PRs #132 and #133 — backend APIs (after release)

## Test plan

- [x] 155 tests pass
- [x] No logic changes — version string only

https://claude.ai/code/session_01CTKnetPke9GCb9Mj717WjP